### PR TITLE
Dxp 108 create genlayer client like viem examples

### DIFF
--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -1,7 +1,7 @@
-import {GenLayerClient, TransactionHash, GenLayerChain, Address} from "../types";
+import {TransactionHash, GenLayerChain, Address, BaseActionsClient} from "../types";
 import {localnet} from "../chains";
 
-export function accountActions(client: GenLayerClient<GenLayerChain>) {
+export function accountActions<TChain extends GenLayerChain>(client: BaseActionsClient<TChain>) {
   return {
     fundAccount: async ({address, amount}: {address: Address; amount: number}): Promise<TransactionHash> => {
       if (client.chain?.id !== localnet.id) {

--- a/src/chains/actions.ts
+++ b/src/chains/actions.ts
@@ -1,4 +1,4 @@
-import {GenLayerClient, GenLayerChain, BaseActionsClient} from "@/types";
+import {GenLayerChain, BaseActionsClient} from "@/types";
 import {testnetAsimov} from "./testnetAsimov";
 
 export function chainActions<TChain extends GenLayerChain>(client: BaseActionsClient<TChain>) {

--- a/src/chains/actions.ts
+++ b/src/chains/actions.ts
@@ -1,7 +1,7 @@
-import {GenLayerClient, GenLayerChain} from "@/types";
+import {GenLayerClient, GenLayerChain, BaseActionsClient} from "@/types";
 import {testnetAsimov} from "./testnetAsimov";
 
-export function chainActions(client: GenLayerClient<GenLayerChain>) {
+export function chainActions<TChain extends GenLayerChain>(client: BaseActionsClient<TChain>) {
   return {
     initializeConsensusSmartContract: async (forceReset: boolean = false): Promise<void> => {
       if (client.chain?.id === testnetAsimov.id) {

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -12,7 +12,19 @@ import {
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs} from "viem";
 
-export const contractActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => {
+type ContractCapabilities = {
+  chain: GenLayerChain;
+  account?: Account;
+  request: GenLayerClient<GenLayerChain>["request"];
+  prepareTransactionRequest: GenLayerClient<GenLayerChain>["prepareTransactionRequest"];
+  sendRawTransaction: GenLayerClient<GenLayerChain>["sendRawTransaction"];
+  getCurrentNonce: GenLayerClient<GenLayerChain>["getCurrentNonce"];
+};
+
+export const contractActions = (
+  client: ContractCapabilities,
+  publicClient: PublicClient,
+) => {
   return {
     getContractSchema: async (address: Address): Promise<ContractSchema> => {
       if (client.chain.id !== localnet.id) {
@@ -186,7 +198,7 @@ const _encodeAddTransactionData = ({
   data,
   consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
 }: {
-  client: GenLayerClient<GenLayerChain>;
+  client: ContractCapabilities;
   senderAccount?: Account;
   recipient?: `0x${string}`;
   data?: `0x${string}`;
@@ -210,7 +222,7 @@ const _encodeSubmitAppealData = ({
   client,
   txId,
 }: {
-  client: GenLayerClient<GenLayerChain>;
+  client: ContractCapabilities;
   txId: `0x${string}`;
 }): `0x${string}` => {
   return encodeFunctionData({
@@ -227,7 +239,7 @@ const _sendTransaction = async ({
   senderAccount,
   value = 0n,
 }: {
-  client: GenLayerClient<GenLayerChain>;
+  client: ContractCapabilities;
   publicClient: PublicClient;
   encodedData: `0x${string}`;
   senderAccount?: Account;

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -1,4 +1,4 @@
-import {GenLayerClient, BaseActionsClient} from "../types/clients";
+import {BaseActionsClient} from "../types/clients";
 import {TransactionHash, TransactionStatus, GenLayerTransaction, GenLayerRawTransaction, transactionsStatusNameToNumber} from "@/types";
 import {transactionsConfig} from "../config/transactions";
 import {sleep} from "../utils/async";

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -1,11 +1,5 @@
-import {GenLayerClient} from "../types/clients";
-import {
-  TransactionHash,
-  TransactionStatus,
-  GenLayerTransaction,
-  GenLayerRawTransaction,
-  transactionsStatusNameToNumber,
-} from "../types/transactions";
+import {GenLayerClient, BaseActionsClient} from "../types/clients";
+import {TransactionHash, TransactionStatus, GenLayerTransaction, GenLayerRawTransaction, transactionsStatusNameToNumber} from "@/types";
 import {transactionsConfig} from "../config/transactions";
 import {sleep} from "../utils/async";
 import {GenLayerChain} from "@/types";
@@ -15,7 +9,14 @@ import {decodeLocalnetTransaction, decodeTransaction, simplifyTransactionReceipt
 
 
 
-export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => ({
+type ClientWithGetTransaction<TChain extends GenLayerChain> = BaseActionsClient<TChain> & {
+  getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
+};
+
+export const receiptActions = <TChain extends GenLayerChain>(
+  client: ClientWithGetTransaction<TChain>,
+  publicClient: PublicClient,
+) => ({
   waitForTransactionReceipt: async ({
     hash,
     status = TransactionStatus.ACCEPTED,
@@ -68,16 +69,29 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
   },
 });
 
-export const transactionActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => ({
+type TransactionCapabilities<TChain extends GenLayerChain> = BaseActionsClient<TChain> & {
+  // using viem public client for remote branch
+};
+
+export const transactionActions = <TChain extends GenLayerChain>(
+  client: TransactionCapabilities<TChain>,
+  publicClient: PublicClient,
+) => ({
   getTransaction: async ({hash}: {hash: TransactionHash}): Promise<GenLayerTransaction> => {
     if (client.chain.id === localnet.id) {
-      const transaction = await client.getTransaction({hash});
+      // Not using viem's getTransaction here: its protected action signature and return type
+      // differ from our GenLayerTransaction (localnet adds consensus fields). Direct RPC avoids
+      // signature conflicts and preserves our expected types.
+      const transaction = (await client.request({
+        method: "eth_getTransactionByHash",
+        params: [hash],
+      })) as GenLayerTransaction;
       const localnetStatus =
         (transaction.status as string) === "ACTIVATED" ? TransactionStatus.PENDING : transaction.status;
 
       transaction.status = Number(transactionsStatusNameToNumber[localnetStatus as TransactionStatus]);
       transaction.statusName = localnetStatus as TransactionStatus;
-      return decodeLocalnetTransaction(transaction as unknown as GenLayerTransaction);
+      return decodeLocalnetTransaction(transaction);
     }
     const transaction = (await publicClient.readContract({
       address: client.chain.consensusDataContract?.address as Address,

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -84,3 +84,17 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       txId: `0x${string}`;
     }) => Promise<any>;
   };
+
+// Base client shape after applying viem public and wallet actions, used by action factories
+export type BaseActionsClient<TGenLayerChain extends GenLayerChain> = Client<
+  Transport,
+  TGenLayerChain
+> &
+  Omit<PublicActions<Transport, TGenLayerChain>, "getTransaction" | "readContract" | "waitForTransactionReceipt"> &
+  WalletActions<TGenLayerChain> & {
+    request: Client<Transport, TGenLayerChain>["request"] & {
+      <TMethod extends GenLayerMethod>(
+        args: Extract<GenLayerMethod, {method: TMethod["method"]}>,
+      ): Promise<unknown>;
+    };
+  };

--- a/src/wallet/actions.ts
+++ b/src/wallet/actions.ts
@@ -1,8 +1,8 @@
 import {connect} from "./connect";
-import {GenLayerClient, GenLayerChain, Network, SnapSource} from "@/types";
+import {GenLayerChain, Network, SnapSource, BaseActionsClient} from "@/types";
 import {metamaskClient} from "@/wallet/metamaskClient";
 
-export function walletActions(client: GenLayerClient<GenLayerChain>) {
+export function walletActions<TChain extends GenLayerChain>(client: BaseActionsClient<TChain>) {
   return {
     connect: (network: Network, snapSource: SnapSource) => connect(client, network, snapSource),
     metamaskClient: (snapSource: SnapSource = "npm") => metamaskClient(snapSource),

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -13,7 +13,7 @@ const networks = {
 };
 
 export const connect = async (
-  client: { chain: GenLayerChain },
+  client: { chain?: GenLayerChain },
   network: Network = "studionet",
   snapSource: SnapSource = "npm",
 ): Promise<void> => {

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -1,7 +1,7 @@
 import {localnet} from "@/chains/localnet";
 import {studionet} from "@/chains/studionet";
 import {testnetAsimov} from "@/chains/testnetAsimov";
-import {GenLayerClient, GenLayerChain} from "@/types";
+import {GenLayerChain} from "@/types";
 import {Network} from "@/types/network";
 import {SnapSource} from "@/types/snapSource";
 import {snapID} from "@/config/snapID";
@@ -13,7 +13,7 @@ const networks = {
 };
 
 export const connect = async (
-  client: GenLayerClient<GenLayerChain>,
+  client: { chain: GenLayerChain },
   network: Network = "studionet",
   snapSource: SnapSource = "npm",
 ): Promise<void> => {


### PR DESCRIPTION
### What
- Replace unsafe `unknown` casts with precise types via new `BaseActionsClient` and capability-based typings.
- Refactor `createClient` to use viem-style `.extend(...)` only for non-conflicting actions and typed object merges for conflicting ones.
- Type action factories (`accounts`, `chains`, `wallet`) to accept `BaseActionsClient`.
- Introduce `ContractCapabilities` to type `contracts/actions.ts` helpers (`_encodeAddTransactionData`, `_sendTransaction`, etc.).
- Keep `receiptActions` typed with a client that includes our own `getTransaction`.
- Localnet: call `eth_getTransactionByHash` directly and adapt to `GenLayerTransaction` before `decodeLocalnetTransaction` (with a short comment explaining viem signature/return-type conflict).
- Relax `wallet/connect` client param to `{ chain: GenLayerChain }`.
- Import `GenLayerRawTransaction` from `@/types` for testnet path.

### Why
- Avoid `unknown`/`any` and align with viem’s extension model while preserving our API surface.
- Prevent collisions with viem’s protected action names and signatures (`getTransaction`, `readContract`, `waitForTransactionReceipt`).
- Fix runtime regression in `waitForTransactionReceipt` on localnet caused by decoding testnet-shaped data.

### Testing done
- Built the package and ran CLI flows:
  - Verified `waitForTransactionReceipt` on localnet.
  - Exercised `getTransaction` on localnet and studionet networks.
  - Sanity-checked `getContractSchemaForCode`, `deployContract`, and `writeContract` flows.
- Linting: resolved all type errors across edited files.

### Decisions made
- Do not override viem’s protected actions via `.extend` when our signatures differ; merge custom actions instead.
- Keep viem’s actions for base functionality; add GenLayer-specific behavior as separate typed actions.
- For localnet `getTransaction`, do not use viem’s `getTransaction` due to signature and return-type differences; use direct RPC and normalize.
- Relax `wallet/connect` input type to avoid over-constraining callers.

### Checks
- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips
- Start with `src/types/clients.ts` for the new `BaseActionsClient`.
- Review `src/client/client.ts` to see the mixed extend/merge composition.
- Skim action factories (`accounts`, `chains`, `wallet`, `contracts`, `transactions`) focusing on their input types and removal of casts.
- Pay attention to the short comment in `src/transactions/actions.ts` explaining why viem’s `getTransaction` isn’t used on localnet.

### User facing release notes
- Improved TypeScript safety across client and actions; removed internal `unknown` casts.
- Fixed a localnet regression in transaction receipt polling.
- No breaking changes to the public API; behavior preserved with stronger typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Broader multi‑chain support across accounts, chains, wallets, contracts, transactions, and receipts for wider network compatibility.

- **Refactor**
  - Rebuilt client assembly using a safer merge pipeline to avoid action name conflicts.
  - Streamlined local‑network transaction/receipt retrieval and generalized action factories; runtime behavior unchanged.

- **Chores**
  - Consolidated and modernized public types/imports and API signatures for clearer typing and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->