### PR TITLE
feat: format in genlayer js to convert to an object

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -46,6 +46,7 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;
+      jsonSafeReturn?: boolean;
       transactionHashVariant?: TransactionHashVariant;
     }) => Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable>;
     writeContract: (args: {

--- a/src/utils/jsonifier.ts
+++ b/src/utils/jsonifier.ts
@@ -1,4 +1,7 @@
 import {calldata} from "@/abi";
+import type {CalldataEncodable} from "@/types/calldata";
+import {CalldataAddress} from "@/types/calldata";
+import {toHex} from "viem";
 
 
 export function b64ToArray(b64: string): Uint8Array {
@@ -44,4 +47,73 @@ export function resultToUserFriendlyJson(cd64: string): any {
     status,
     payload,
   };
+}
+
+// Deeply converts CalldataEncodable values into JSON-serializable structures.
+// Rules:
+// - bigint: to number if safe, otherwise to decimal string
+// - Uint8Array: to 0x-prefixed hex string
+// - CalldataAddress: to 0x-prefixed hex string
+// - Map: to Array<[key, value]> preserving order
+// - Arrays and plain objects: converted recursively
+export function toJsonSafeDeep<T extends CalldataEncodable>(value: T): any {
+  return _toJsonSafeDeep(value, new WeakSet());
+}
+
+function _toJsonSafeDeep(value: CalldataEncodable, seen: WeakSet<object>): any {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const primitiveType = typeof value;
+  if (primitiveType === "string" || primitiveType === "boolean" || primitiveType === "number") {
+    return value;
+  }
+
+  if (primitiveType === "bigint") {
+    const big = value as bigint;
+    const abs = big < 0n ? -big : big;
+    const maxSafe = 9007199254740991n; // Number.MAX_SAFE_INTEGER
+    return abs <= maxSafe ? Number(big) : big.toString();
+  }
+
+  // Objects and structured values
+  if (typeof value === "object") {
+    if (seen.has(value as object)) {
+      // Prevent potential cycles; represent as null
+      return null;
+    }
+    seen.add(value as object);
+
+    if (value instanceof Uint8Array) {
+      return toHex(value);
+    }
+
+    if (value instanceof Array) {
+      return value.map((v) => _toJsonSafeDeep(v as CalldataEncodable, seen));
+    }
+
+    if (value instanceof Map) {
+      const obj: Record<string, any> = {};
+      for (const [k, v] of value.entries()) {
+        obj[k] = _toJsonSafeDeep(v as CalldataEncodable, seen);
+      }
+      return obj;
+    }
+
+    if (value instanceof CalldataAddress) {
+      return toHex(value.bytes);
+    }
+
+    if (Object.getPrototypeOf(value) === Object.prototype) {
+      const obj: Record<string, any> = {};
+      for (const [k, v] of Object.entries(value)) {
+        obj[k] = _toJsonSafeDeep(v as CalldataEncodable, seen);
+      }
+      return obj;
+    }
+  }
+
+  // Fallback: return as-is (shouldn't normally reach here)
+  return value as any;
 }


### PR DESCRIPTION
### What
- Added deep JSON-safe conversion utility to handle decoded contract returns:
  - Map → plain object
  - bigint → number if safe, otherwise decimal string
  - Uint8Array → 0x-hex string
  - CalldataAddress → 0x-hex string
  - Recursive handling for nested arrays/objects/maps and cycle protection
- Added `jsonSafeReturn?: boolean` option to `readContract` (default false) to return decoded results as JSON-safe objects
- Updated types to expose `jsonSafeReturn` in `GenLayerClient.readContract` signature

### Why
- Contract reads can return complex structures (Maps, bigints, nested objects) that break JSON parsing and standard console logging
- The CLI uses Node’s `inspect` for logs; we also need an option to return a JSON-safe object for programmatic consumption
- Preserves backward compatibility by keeping the default behavior unchanged

### Testing done
- Manually tested using Rally’s project by calling `get_submissions`
- Manually tested with `wizard_of_coin` and `football_prediction_market` contracts
- Verified:
  - Nested Maps and arrays convert correctly into plain objects
  - BigInts convert to number when within Number.MAX_SAFE_INTEGER, otherwise to string
  - `Uint8Array` and `CalldataAddress` render as 0x-prefixed hex
  - Default behavior (without `jsonSafeReturn`) remains unchanged

### Decisions made
- BigInt conversion: number if abs(value) <= Number.MAX_SAFE_INTEGER, else decimal string for safety
- Map conversion: to plain object for better ergonomics and JSON serialization
- Byte-like values (`Uint8Array`) and addresses (`CalldataAddress`) standardized to 0x-hex strings
- Cycle handling: break potential reference cycles with a `WeakSet` and return `null` when a cycle is detected
- API shape: opt-in via `jsonSafeReturn` with default false to avoid breaking changes

### Checks
- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips
- Focus on:
  - `src/contracts/actions.ts`: new `jsonSafeReturn` option and application post-decode
  - `src/utils/jsonifier.ts`: `toJsonSafeDeep` implementation and conversion rules
  - `src/types/clients.ts`: updated `readContract` signature
- Pay extra attention to bigint and Map conversions and the cycle handling logic

### User facing release notes
- Added `jsonSafeReturn` option to `readContract`. When enabled, decoded contract results are returned as JSON-safe objects:
  - Map → plain object
  - bigint → number (if safe) or string
  - `Uint8Array`/`CalldataAddress` → 0x-hex strings
  - Works recursively for nested structures
- Default behavior remains unchanged; enable with:
  ```ts
  const result = await client.readContract({
    address,
    functionName: "myFn",
    jsonSafeReturn: true,
  });
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional jsonSafeReturn flag to readContract. When enabled, results are returned in a JSON-safe format (e.g., large integers and binary data are converted to serializable values), reducing serialization errors with complex or nested data.
  * Backward compatible: default behavior unchanged unless jsonSafeReturn is explicitly set to true.
  * Deep serialization now handles arrays, maps, addresses, binary blobs and detects cycles to avoid infinite recursion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->