### PR TITLE
feat(contracts,types): add getContractCode via gen_getContractCode RPC

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -11,9 +11,21 @@ import {
   TransactionHashVariant,
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs} from "viem";
+import {b64ToArray} from "@/utils/jsonifier";
 
 export const contractActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => {
   return {
+    getContractCode: async (address: Address): Promise<string> => {
+      if (client.chain.id !== localnet.id) {
+        throw new Error("Getting contract code is not supported on this network");
+      }
+      const result = (await client.request({
+        method: "gen_getContractCode",
+        params: [address],
+      })) as string;
+      const codeBytes = b64ToArray(result);
+      return new TextDecoder().decode(codeBytes);
+    },
     getContractSchema: async (address: Address): Promise<ContractSchema> => {
       if (client.chain.id !== localnet.id) {
         throw new Error("Contract schema is not supported on this network");

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -15,6 +15,7 @@ export type GenLayerMethod =
   | {method: "eth_sendRawTransaction"; params: [signedTransaction: string]}
   | {method: "gen_getContractSchema"; params: [address: Address]}
   | {method: "gen_getContractSchemaForCode"; params: [contractCode: string]}
+  | {method: "gen_getContractCode"; params: [address: Address]}
   | {method: "sim_getTransactionsForAddress"; params: [address: Address, filter?: "all" | "from" | "to"]}
   | {method: "eth_getTransactionCount"; params: [address: Address, block: string]}
   | {method: "gen_call"; params: [requestParams: any]};
@@ -76,6 +77,7 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
     }) => Promise<GenLayerTransaction>;
     getContractSchema: (address: Address) => Promise<ContractSchema>;
     getContractSchemaForCode: (contractCode: string | Uint8Array) => Promise<ContractSchema>;
+    getContractCode: (address: Address) => Promise<string>;
     initializeConsensusSmartContract: (forceReset?: boolean) => Promise<void>;
     connect: (network?: Network, snapSource?: SnapSource) => Promise<void>;
     metamaskClient: (snapSource?: SnapSource) => Promise<MetaMaskClientResult>;


### PR DESCRIPTION
### What
- Added `getContractCode(address)` to `contracts.actions` calling `gen_getContractCode` RPC
- Decoded base64 result to UTF-8 using `b64ToArray` + `TextDecoder`
- Extended `GenLayerMethod` and `GenLayerClient` types to include the new RPC and client method

### Why
- Enable fetching raw contract code by address for inspection, debugging, and tooling
- Provide a simple, typed API for consumers to retrieve decoded code

### Testing done
- Manual call to `client.getContractCode(address)` on localnet, verified decoded string output
- Type-check and lints pass

### Decisions made
- Restricted feature to `localnet` pending broader network support
- Reused existing `b64ToArray` utility for consistency

### Checks
- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips
- Focus on `src/contracts/actions.ts` for the new method and network guard
- Confirm `src/types/clients.ts` union/type additions align with usage

### User facing release notes
- New `client.getContractCode(address)` method to fetch and decode contract code via `gen_getContractCode` RPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added the ability to retrieve a contract’s code by address when connected to a local network. The result is returned as a UTF-8 string for easier inspection and tooling integration.
  - This capability is intentionally disabled on non-local networks and will indicate that the operation is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->