### PR TITLE
fix(client): disable viem transport retries (retryCount=0) to avoid d…

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -89,7 +89,7 @@ export const createClient = (config: ClientConfig = {chain: localnet}): GenLayer
     chainConfig.rpcUrls.default.http = [config.endpoint];
   }
 
-  const customTransport = custom(getCustomTransportConfig(config));
+  const customTransport = custom(getCustomTransportConfig(config), {retryCount: 0, retryDelay: 0});
   const publicClient = createPublicClient(chainConfig as GenLayerChain, customTransport).extend(
     publicActions,
   );


### PR DESCRIPTION
## What
- Disabled viem retries in custom transport by setting `retryCount: 0` and `retryDelay: 0` in `createClient`.

## Why
- Prevent multiple identical RPC calls and repeated error logs on failures.
- Make errors deterministic and easier to debug for users.

## Testing done
- Called `readContract` on a failing method and observed a single request and single error.
- Sanity-checked successful calls still return as expected.

## Decisions made
- Disabled retries globally at the transport level to ensure single-attempt behavior.

## Checks
- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

## Reviewing tips
- Focus on `src/client/client.ts`, particularly the `custom(getCustomTransportConfig(config), { retryCount: 0, retryDelay: 0 })` change.

## User facing release notes
- Requests are no longer retried by default; failures return immediately, reducing duplicate RPC calls and repeated error logs.