### PR TITLE
fix: returning the whole data when an error occurs

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -70,12 +70,12 @@ const getCustomTransportConfig = (config: ClientConfig) => {
           const data = await response.json();
 
           if (data.error) {
-            throw new Error(data.error.message);
+            throw data.error
           }
 
           return data.result;
         } catch (err) {
-          console.error(`Error fetching ${method} from GenLayer RPC:`, err);
+          console.error(`Error fetching ${method} from GenLayer RPC`);
           throw err;
         }
       }


### PR DESCRIPTION
### What
- Throw the full JSON-RPC `error` object (`throw data.error`) instead of wrapping it with `new Error(error.message)`.
- Removed the `err` argument from the `console.error` call to avoid duplicated logs across our tools.

### Why
- Wrapping with `new Error` hides nested fields (like `error.data`) and makes nested objects unavailable when catching/logging in other methods.
- Throwing the original `data.error` preserves all fields, so when a call fails, we now return the entire receipt error via `error.data`.
- Removing the error object from the log call prevents duplicate error logs across the toolchain.

### Testing done
- Manually triggered a failing `gen_call` and confirmed the full receipt is accessible via `error.data` on the thrown error.
- Verified successful calls continue returning `data.result` unchanged.

### Decisions made
- Prefer throwing the original JSON-RPC error over re-wrapping to retain structure and metadata.
- Keep logging concise (message only) to avoid duplicate logs while preserving context in the thrown error.

### Checks
- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips
- Change is localized to `src/client/client.ts`. Review how consumers handle errors: they can now access the receipt under `error.data` when failures occur. Success paths are unchanged.

### User facing release notes
- Client now throws the full JSON-RPC error. On failures, the complete receipt is available via `error.data`, enabling consumers to access error receipts (e.g., for `gen_call`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RPC errors are now surfaced directly, improving accuracy of error messages and handling in the app.

* **Refactor**
  * Simplified RPC failure logging to a concise, consistent message, reducing console noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->