### PR TITLE
feat: allow gen_call write through `simulateWriteContract`

### DIFF
--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -59,6 +59,16 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
     }) => Promise<any>;
+    simulateWriteContract: (args: {
+      account?: Account;
+      address: Address;
+      functionName: string;
+      args?: CalldataEncodable[];
+      kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
+      value: bigint;
+      leaderOnly?: boolean;
+      consensusMaxRotations?: number;
+    }) => Promise<any>;
     deployContract: (args: {
       account?: Account;
       code: string | Uint8Array;

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -59,16 +59,16 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
     }) => Promise<any>;
-    simulateWriteContract: (args: {
+    simulateWriteContract: <RawReturn extends boolean | undefined>(args: {
       account?: Account;
       address: Address;
       functionName: string;
       args?: CalldataEncodable[];
-      kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
-      value: bigint;
+      kwargs?: Map<string, CalldataEncodable> | { [key: string]: CalldataEncodable };
+      rawReturn?: RawReturn;
       leaderOnly?: boolean;
-      consensusMaxRotations?: number;
-    }) => Promise<any>;
+      transactionHashVariant?: TransactionHashVariant;
+    }) => Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable>;
     deployContract: (args: {
       account?: Account;
       code: string | Uint8Array;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulate contract write operations (dry-run) via the client API, mirroring the existing read flow.
  * Optionally return raw hex or decoded results, and specify execution parameters such as account, leader-only mode, and transaction-hash variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->