### PR TITLE
Route read RPC methods directly to node for injected wallets

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -35,10 +35,32 @@ interface ClientConfig {
 
 const getCustomTransportConfig = (config: ClientConfig, chainConfig: GenLayerChain) => {
   const isAddress = typeof config.account !== "object";
+  const providerMethods = new Set<string>([
+    "eth_chainId",
+    "eth_accounts",
+    "eth_requestAccounts",
+    "eth_sendTransaction",
+    "eth_sign",
+    "eth_signTypedData",
+    "eth_signTypedData_v4",
+    "personal_sign",
+    "wallet_addEthereumChain",
+    "wallet_getPermissions",
+    "wallet_requestPermissions",
+    "wallet_switchEthereumChain",
+  ]);
 
   return {
     async request({method, params = []}: {method: string; params: any[]}) {
-      if (method.startsWith("eth_") && isAddress) {
+      const shouldUseProvider =
+        isAddress &&
+        (
+          providerMethods.has(method) ||
+          method.startsWith("wallet_") ||
+          method.endsWith("_signTypedData") ||
+          method.endsWith("_signTypedData_v4")
+        );
+      if (shouldUseProvider) {
         const provider = config.provider || (typeof window !== "undefined" ? window.ethereum : undefined);
         if (provider) {
           try {


### PR DESCRIPTION
## Summary
- route only wallet/signing methods through the injected provider
- keep read/tx-polling RPC methods on direct node fetch transport
- add tests to lock method routing for `eth_sendTransaction`, `eth_chainId`, and `eth_getTransactionByHash`

## Why
Injected providers can alter or normalize read responses, which breaks localnet-specific transaction polling paths that expect GenLayer fields like `status`.

## Validation
- `npm test -- --run tests/client.test.ts tests/contracts-actions.test.ts tests/transactions.test.ts`
