### PR TITLE
fix: use isStudio instead of localnet.id for feature guards

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -48,6 +48,11 @@ const assertChainMatch = async (
   provider: EthereumProvider | {request: (args: {method: string; params?: any[]}) => Promise<any>},
   chainConfig: GenLayerChain,
 ) => {
+  // Studio chains manage wallet switching externally (useChainEnforcer).
+  // The SDK chain ID (e.g., localnet=61127) may differ from the per-instance
+  // chain ID MetaMask is on (e.g., 61997/61998/61999). Skip validation for Studio.
+  if (chainConfig.isStudio) return;
+
   const expectedChainIdHex = `0x${chainConfig.id.toString(16)}`;
   try {
     const currentChainId = await provider.request({method: "eth_chainId"});

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,6 +1,6 @@
 import * as calldata from "@/abi/calldata";
 import {serialize} from "@/abi/transactions";
-import {localnet} from "@/chains/localnet";
+
 import {
   Account,
   ContractSchema,
@@ -35,10 +35,10 @@ function extractGenCallResult(result: unknown): `0x${string}` {
 
 export const contractActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => {
   return {
-    /** Retrieves the source code of a deployed contract. Localnet only. */
+    /** Retrieves the source code of a deployed contract. Studio only. */
     getContractCode: async (address: Address): Promise<string> => {
-      if (client.chain.id !== localnet.id) {
-        throw new Error(`getContractCode is only available on localnet (current chain: ${client.chain.name})`);
+      if (!client.chain.isStudio) {
+        throw new Error(`getContractCode is only available on Studio networks (current chain: ${client.chain.name})`);
       }
       const result = (await client.request({
         method: "gen_getContractCode",
@@ -47,10 +47,10 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       const codeBytes = b64ToArray(result);
       return new TextDecoder().decode(codeBytes);
     },
-    /** Gets the schema (methods and constructor) of a deployed contract. Localnet only. */
+    /** Gets the schema (methods and constructor) of a deployed contract. Studio only. */
     getContractSchema: async (address: Address): Promise<ContractSchema> => {
-      if (client.chain.id !== localnet.id) {
-        throw new Error(`getContractSchema is only available on localnet (current chain: ${client.chain.name})`);
+      if (!client.chain.isStudio) {
+        throw new Error(`getContractSchema is only available on Studio networks (current chain: ${client.chain.name})`);
       }
       const schema = (await client.request({
         method: "gen_getContractSchema",
@@ -58,10 +58,10 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       })) as string;
       return schema as unknown as ContractSchema;
     },
-    /** Generates a schema for contract code without deploying it. Localnet only. */
+    /** Generates a schema for contract code without deploying it. Studio only. */
     getContractSchemaForCode: async (contractCode: string | Uint8Array): Promise<ContractSchema> => {
-      if (client.chain.id !== localnet.id) {
-        throw new Error(`getContractSchema is only available on localnet (current chain: ${client.chain.name})`);
+      if (!client.chain.isStudio) {
+        throw new Error(`getContractSchemaForCode is only available on Studio networks (current chain: ${client.chain.name})`);
       }
       const schema = (await client.request({
         method: "gen_getContractSchemaForCode",
@@ -751,9 +751,14 @@ const _sendTransaction = async ({
       params: [formattedRequest as any],
     })) as `0x${string}`;
 
-    // Extract GenLayer txId from the NewTransaction event, same as local account path.
-    // On studio RPCs this may already be the GenLayer txId, but on testnets
-    // eth_sendTransaction returns the EVM tx hash which is not the GenLayer tx ID.
+    if (client.chain.isStudio) {
+      // Studio RPCs process eth_sendRawTransaction internally (MetaMask signs
+      // and forwards). The returned hash IS the GenLayer tx hash — no need to
+      // wait for an EVM receipt or extract txId from logs.
+      return evmTxHash;
+    }
+
+    // On real testnets, extract GenLayer txId from the NewTransaction event.
     const externalReceipt = await publicClient.waitForTransactionReceipt({hash: evmTxHash});
 
     if (externalReceipt.status === "reverted") {

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -44,7 +44,7 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
       (status === TransactionStatus.ACCEPTED && isDecidedState(transactionStatusString))
     ) {
       let finalTransaction = transaction;
-      if (client.chain.id === localnet.id) {
+      if (client.chain.isStudio) {
         finalTransaction = decodeLocalnetTransaction(transaction as unknown as GenLayerTransaction);
       }
       if (!fullTransaction) {


### PR DESCRIPTION
## Summary
Multiple Studio instances need unique chain IDs for MetaMask, but SDK guards blocked schema/code methods for any chain ID != 61127 (localnet).

### Changes
- `getContractCode/Schema/SchemaForCode`: guard with `!isStudio` instead of `chain.id !== localnet.id`
- `decodeLocalnetTransaction`: guard with `isStudio` instead of `=== localnet.id`
- `assertChainMatch`: skip for Studio chains (SDK chain ID may differ from per-instance MetaMask chain ID)
- External wallet `_sendTransaction`: skip `waitForTransactionReceipt` on Studio (no real EVM receipts), return hash directly

### Context
Studio deployments: dev=61997, stg=61998, prod=61999, rally-dev=61898, rally-prod=61899. All are `isStudio=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Studio network transaction handling and wallet validation to reduce processing overhead and improve confirmation speed.
  * Enhanced contract operations logic specifically for Studio environments.
  * Streamlined transaction processing workflow for improved user experience on Studio chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->