### PR TITLE
fix(chains): refresh testnetAsimov + testnetBradbury from genlayer-networks

### DIFF
--- a/src/chains/testnetAsimov.ts
+++ b/src/chains/testnetAsimov.ts
@@ -2,7 +2,6 @@ import {Address, defineChain} from "viem";
 import {GenLayerChain} from "@/types";
 import {STAKING_ABI} from "@/abi/staking";
 
-// chains/localnet.ts
 const TESTNET_JSON_RPC_URL = "https://rpc-asimov.genlayer.com";
 // WebSocket not available on testnet GenLayer RPC nodes
 
@@ -10,3976 +9,3359 @@ const STAKING_CONTRACT = {
   address: "0x63Fa5E0bb10fb6fA98F44726C5518223F767687A" as Address,
   abi: STAKING_ABI,
 };
+const FEE_MANAGER_CONTRACT = {
+  address: "0x21737AA4bea8FF12E202BF1BAB23751A95617533" as Address,
+  abi: [
+    {
+      type: "function" as const,
+      name: "calculateMinAppealBond",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "_txId", type: "bytes32" },
+        { name: "_round", type: "uint256" },
+        { name: "_status", type: "uint8" },
+      ],
+      outputs: [
+        { name: "totalFeesToPay", type: "uint256" },
+      ],
+    },
+  ],
+};
+const ROUNDS_STORAGE_CONTRACT = {
+  address: "0x1F595c0D549DE0812F127508ea1039636CFA62Cc" as Address,
+  abi: [
+    {
+      type: "function" as const,
+      name: "getLastRoundData",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "txId", type: "bytes32" },
+      ],
+      outputs: [
+        { name: "round", type: "uint256" },
+        {
+          name: "roundData",
+          type: "tuple",
+          components: [
+          { name: "round", type: "uint256" },
+          { name: "leaderIndex", type: "uint256" },
+          { name: "votesCommitted", type: "uint256" },
+          { name: "votesRevealed", type: "uint256" },
+          { name: "appealBond", type: "uint256" },
+          { name: "rotationsLeft", type: "uint256" },
+          { name: "result", type: "uint8" },
+          { name: "roundValidators", type: "address[]" },
+          { name: "validatorVotes", type: "uint8[]" },
+          { name: "validatorVotesHash", type: "bytes32[]" },
+          { name: "validatorResultHash", type: "bytes32[]" },
+          ],
+        },
+      ],
+    },
+    {
+      type: "function" as const,
+      name: "getRoundData",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "txId", type: "bytes32" },
+        { name: "round", type: "uint256" },
+      ],
+      outputs: [
+        {
+          name: "",
+          type: "tuple",
+          components: [
+          { name: "round", type: "uint256" },
+          { name: "leaderIndex", type: "uint256" },
+          { name: "votesCommitted", type: "uint256" },
+          { name: "votesRevealed", type: "uint256" },
+          { name: "appealBond", type: "uint256" },
+          { name: "rotationsLeft", type: "uint256" },
+          { name: "result", type: "uint8" },
+          { name: "roundValidators", type: "address[]" },
+          { name: "validatorVotes", type: "uint8[]" },
+          { name: "validatorVotesHash", type: "bytes32[]" },
+          { name: "validatorResultHash", type: "bytes32[]" },
+          ],
+        },
+      ],
+    },
+    {
+      type: "function" as const,
+      name: "getRoundNumber",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "txId", type: "bytes32" },
+      ],
+      outputs: [
+        { name: "", type: "uint256" },
+      ],
+    },
+  ],
+};
+const APPEALS_CONTRACT = {
+  address: "0x0F739Dd8f5322b9547c7d19a9621BC2ac8DF4089" as Address,
+  abi: [
+    {
+      type: "function" as const,
+      name: "canAppeal",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "_txId", type: "bytes32" },
+      ],
+      outputs: [
+        { name: "", type: "bool" },
+      ],
+    },
+  ],
+};
 const EXPLORER_URL = "https://explorer-asimov.genlayer.com/";
 const CONSENSUS_MAIN_CONTRACT = {
   address: "0x6CAFF6769d70824745AD895663409DC70aB5B28E" as Address,
   abi: [
-    {
-      inputs: [],
-      name: "AccessControlBadConfirmation",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          internalType: "bytes32",
-          name: "neededRole",
-          type: "bytes32",
-        },
-      ],
-      name: "AccessControlUnauthorizedAccount",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "CallerNotMessages",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "CanNotAppeal",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "EmptyTransaction",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "FinalizationNotAllowed",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "InvalidAddress",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "InvalidGhostContract",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "InvalidInitialization",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "InvalidVote",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "MaxNumOfIterationsInPendingQueueReached",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "uint256",
-          name: "numOfMessages",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "maxAllocatedMessages",
-          type: "uint256",
-        },
-      ],
-      name: "MaxNumOfMessagesExceeded",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "NonGenVMContract",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "NotInitializing",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "owner",
-          type: "address",
-        },
-      ],
-      name: "OwnableInvalidOwner",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "OwnableUnauthorizedAccount",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "ReentrancyGuardReentrantCall",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "TransactionNotAtPendingQueueHead",
-      type: "error",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "appealer",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "uint256",
-          name: "appealBond",
-          type: "uint256",
-        },
-        {
-          indexed: false,
-          internalType: "address[]",
-          name: "appealValidators",
-          type: "address[]",
-        },
-      ],
-      name: "AppealStarted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "bytes",
-          name: "data",
-          type: "bytes",
-        },
-      ],
-      name: "ErrorMessage",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: false,
-          internalType: "address",
-          name: "ghostFactory",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "genManager",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "genTransactions",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "genQueue",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "genStaking",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "genMessages",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "idleness",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "tribunalAppeal",
-          type: "address",
-        },
-      ],
-      name: "ExternalContractsSet",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: false,
-          internalType: "uint64",
-          name: "version",
-          type: "uint64",
-        },
-      ],
-      name: "Initialized",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "activator",
-          type: "address",
-        },
-      ],
-      name: "InternalMessageProcessed",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "activator",
-          type: "address",
-        },
-      ],
-      name: "NewTransaction",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "address",
-          name: "previousOwner",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "OwnershipTransferStarted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "address",
-          name: "previousOwner",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "OwnershipTransferred",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "previousAdminRole",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "newAdminRole",
-          type: "bytes32",
-        },
-      ],
-      name: "RoleAdminChanged",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "RoleGranted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "RoleRevoked",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "SlashAppealSubmitted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "TransactionAccepted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "leader",
-          type: "address",
-        },
-      ],
-      name: "TransactionActivated",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "TransactionCancelled",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "TransactionFinalized",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "oldValidator",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newValidator",
-          type: "address",
-        },
-      ],
-      name: "TransactionIdleValidatorReplaced",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "uint256",
-          name: "validatorIndex",
-          type: "uint256",
-        },
-      ],
-      name: "TransactionIdleValidatorReplacementFailed",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newLeader",
-          type: "address",
-        },
-      ],
-      name: "TransactionLeaderRotated",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "TransactionLeaderTimeout",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: false,
-          internalType: "bytes32[]",
-          name: "tx_ids",
-          type: "bytes32[]",
-        },
-      ],
-      name: "TransactionNeedsRecomputation",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "tx_id",
-          type: "bytes32",
-        },
-        {
-          indexed: false,
-          internalType: "address[]",
-          name: "validators",
-          type: "address[]",
-        },
-      ],
-      name: "TransactionReceiptProposed",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "TransactionUndetermined",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "validator",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "bool",
-          name: "isLastVote",
-          type: "bool",
-        },
-      ],
-      name: "TribunalAppealVoteCommitted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "validator",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "bool",
-          name: "isLastVote",
-          type: "bool",
-        },
-      ],
-      name: "TribunalAppealVoteRevealed",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "validator",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "bool",
-          name: "isLastVote",
-          type: "bool",
-        },
-      ],
-      name: "VoteCommitted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "txId",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "validator",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "enum ITransactions.VoteType",
-          name: "voteType",
-          type: "uint8",
-        },
-        {
-          indexed: false,
-          internalType: "bool",
-          name: "isLastVote",
-          type: "bool",
-        },
-        {
-          indexed: false,
-          internalType: "enum ITransactions.ResultType",
-          name: "result",
-          type: "uint8",
-        },
-      ],
-      name: "VoteRevealed",
-      type: "event",
-    },
-    {
-      inputs: [],
-      name: "DEFAULT_ADMIN_ROLE",
-      outputs: [
-        {
-          internalType: "bytes32",
-          name: "",
-          type: "bytes32",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "acceptOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes",
-          name: "_vrfProof",
-          type: "bytes",
-        },
-      ],
-      name: "activateTransaction",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_sender",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "_numOfInitialValidators",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "_maxRotations",
-          type: "uint256",
-        },
-        {
-          internalType: "bytes",
-          name: "_txData",
-          type: "bytes",
-        },
-      ],
-      name: "addTransaction",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-      ],
-      name: "cancelTransaction",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes32",
-          name: "_commitHash",
-          type: "bytes32",
-        },
-      ],
-      name: "commitTribunalAppealVote",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes32",
-          name: "_commitHash",
-          type: "bytes32",
-        },
-      ],
-      name: "commitVote",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "contracts",
-      outputs: [
-        {
-          internalType: "contract IGenManager",
-          name: "genManager",
-          type: "address",
-        },
-        {
-          internalType: "contract ITransactions",
-          name: "genTransactions",
-          type: "address",
-        },
-        {
-          internalType: "contract IQueues",
-          name: "genQueue",
-          type: "address",
-        },
-        {
-          internalType: "contract IGhostFactory",
-          name: "ghostFactory",
-          type: "address",
-        },
-        {
-          internalType: "contract IGenStaking",
-          name: "genStaking",
-          type: "address",
-        },
-        {
-          internalType: "contract IMessages",
-          name: "genMessages",
-          type: "address",
-        },
-        {
-          internalType: "contract IIdleness",
-          name: "idleness",
-          type: "address",
-        },
-        {
-          internalType: "contract ITribunalAppeal",
-          name: "tribunalAppeal",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "_value",
-          type: "uint256",
-        },
-        {
-          internalType: "bytes",
-          name: "_data",
-          type: "bytes",
-        },
-      ],
-      name: "executeMessage",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "success",
-          type: "bool",
-        },
-      ],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-      ],
-      name: "finalizeTransaction",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "getContracts",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "contract IGenManager",
-              name: "genManager",
-              type: "address",
-            },
-            {
-              internalType: "contract ITransactions",
-              name: "genTransactions",
-              type: "address",
-            },
-            {
-              internalType: "contract IQueues",
-              name: "genQueue",
-              type: "address",
-            },
-            {
-              internalType: "contract IGhostFactory",
-              name: "ghostFactory",
-              type: "address",
-            },
-            {
-              internalType: "contract IGenStaking",
-              name: "genStaking",
-              type: "address",
-            },
-            {
-              internalType: "contract IMessages",
-              name: "genMessages",
-              type: "address",
-            },
-            {
-              internalType: "contract IIdleness",
-              name: "idleness",
-              type: "address",
-            },
-            {
-              internalType: "contract ITribunalAppeal",
-              name: "tribunalAppeal",
-              type: "address",
-            },
-          ],
-          internalType: "struct IConsensusMain.ExternalContracts",
-          name: "",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-      ],
-      name: "getRoleAdmin",
-      outputs: [
-        {
-          internalType: "bytes32",
-          name: "",
-          type: "bytes32",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "addr",
-          type: "address",
-        },
-      ],
-      name: "ghostContracts",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "isGhost",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "grantRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "hasRole",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "initialize",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "owner",
-      outputs: [
-        {
-          internalType: "address",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "pendingOwner",
-      outputs: [
-        {
-          internalType: "address",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "proceedPendingQueueProcessing",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes",
-          name: "_txReceipt",
-          type: "bytes",
-        },
-        {
-          internalType: "uint256",
-          name: "_processingBlock",
-          type: "uint256",
-        },
-        {
-          components: [
-            {
-              internalType: "enum IMessages.MessageType",
-              name: "messageType",
-              type: "uint8",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "value",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes",
-              name: "data",
-              type: "bytes",
-            },
-            {
-              internalType: "bool",
-              name: "onAcceptance",
-              type: "bool",
-            },
-          ],
-          internalType: "struct IMessages.SubmittedMessage[]",
-          name: "_messages",
-          type: "tuple[]",
-        },
-        {
-          internalType: "bytes",
-          name: "_vrfProof",
-          type: "bytes",
-        },
-      ],
-      name: "proposeReceipt",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "renounceOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "callerConfirmation",
-          type: "address",
-        },
-      ],
-      name: "renounceRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes32",
-          name: "_voteHash",
-          type: "bytes32",
-        },
-        {
-          internalType: "enum ITribunalAppeal.TribunalVoteType",
-          name: "_voteType",
-          type: "uint8",
-        },
-        {
-          internalType: "uint256",
-          name: "_nonce",
-          type: "uint256",
-        },
-      ],
-      name: "revealTribunalAppealVote",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "bytes32",
-          name: "_voteHash",
-          type: "bytes32",
-        },
-        {
-          internalType: "enum ITransactions.VoteType",
-          name: "_voteType",
-          type: "uint8",
-        },
-        {
-          internalType: "uint256",
-          name: "_nonce",
-          type: "uint256",
-        },
-      ],
-      name: "revealVote",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "revokeRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_ghostFactory",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_genManager",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_genTransactions",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_genQueue",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_genStaking",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_genMessages",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_idleness",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_tribunalAppeal",
-          type: "address",
-        },
-      ],
-      name: "setExternalContracts",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-      ],
-      name: "submitAppeal",
-      outputs: [],
-      stateMutability: "payable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-      ],
-      name: "submitSlashAppeal",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes4",
-          name: "interfaceId",
-          type: "bytes4",
-        },
-      ],
-      name: "supportsInterface",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "transferOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-  ],
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "CallerNotMessages",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDeploymentWithSalt",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRevealLeaderData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidVote",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransactionNotFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldActivator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newActivator",
+        "type": "address"
+      }
+    ],
+    "name": "ActivatorReplaced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "addressManager",
+        "type": "address"
+      }
+    ],
+    "name": "AddressManagerSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ITransactions.TransactionStatus",
+        "name": "newStatus",
+        "type": "uint8"
+      }
+    ],
+    "name": "AllVotesCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "appellant",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "bond",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "validators",
+        "type": "address[]"
+      }
+    ],
+    "name": "AppealStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "attempted",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "succeeded",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "failed",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchFinalizationCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "txSlot",
+        "type": "uint256"
+      }
+    ],
+    "name": "CreatedTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "activator",
+        "type": "address"
+      }
+    ],
+    "name": "InternalMessageProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldLeader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newLeader",
+        "type": "address"
+      }
+    ],
+    "name": "LeaderIdlenessProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "activator",
+        "type": "address"
+      }
+    ],
+    "name": "NewTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ProcessIdlenessAccepted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionAccepted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "leader",
+        "type": "address"
+      }
+    ],
+    "name": "TransactionActivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "cancelledBy",
+        "type": "address"
+      }
+    ],
+    "name": "TransactionCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionFinalizationFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionLeaderRevealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newLeader",
+        "type": "address"
+      }
+    ],
+    "name": "TransactionLeaderRotated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionLeaderTimeout",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "txIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "TransactionNeedsRecomputation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "validators",
+        "type": "address[]"
+      }
+    ],
+    "name": "TransactionReceiptProposed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionUndetermined",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUnissuedValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "unissuedCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnissuedMessagesAtFinalization",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldValidator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newValidator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorReplaced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValueWithdrawalFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLastVote",
+        "type": "bool"
+      }
+    ],
+    "name": "VoteCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ITransactions.VoteType",
+        "name": "voteType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLastVote",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ITransactions.ResultType",
+        "name": "result",
+        "type": "uint8"
+      }
+    ],
+    "name": "VoteRevealed",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EVENTS_BATCH_SIZE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_vrfProof",
+        "type": "bytes"
+      }
+    ],
+    "name": "activateTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_numOfInitialValidators",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxRotations",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_calldata",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validUntil",
+        "type": "uint256"
+      }
+    ],
+    "name": "addTransaction",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "addressManager",
+    "outputs": [
+      {
+        "internalType": "contract IAddressManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "cancelTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_commitHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validatorIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "commitVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_numOfInitialValidators",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxRotations",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_calldata",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_saltNonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validUntil",
+        "type": "uint256"
+      }
+    ],
+    "name": "deploySalted",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "executeMessage",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_txIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "finalizeIdlenessTxs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "finalizeTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "flushExternalMessages",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAddressManager",
+    "outputs": [
+      {
+        "internalType": "contract IAddressManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getPendingTransactionValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "isGhostContract",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "leaderIdleness",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "saltAsAValidator",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagesAndOtherFieldsHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "otherExecutionFieldsHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.VoteType",
+            "name": "resultValue",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct IConsensusMain.LeaderRevealVoteParams",
+        "name": "leaderRevealVoteParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "leaderRevealVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "processIdleness",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "affectedRecipients",
+        "type": "address[]"
+      }
+    ],
+    "name": "promoteNextPendingTransactions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_txExecutionHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_processingBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_eqBlocksOutputs",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_vrfProof",
+        "type": "bytes"
+      }
+    ],
+    "name": "proposeReceipt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_txIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "redButtonFinalize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "ghost",
+        "type": "address"
+      }
+    ],
+    "name": "registerGhostContract",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_voteHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "enum ITransactions.VoteType",
+        "name": "_voteType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_otherExecutionFieldsHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validatorIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "revealVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressManager",
+        "type": "address"
+      }
+    ],
+    "name": "setAddressManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "submitAppeal",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+],
   bytecode: "",
 };
 
 const CONSENSUS_DATA_CONTRACT = {
   address: "0x0D9d1d74d72Fa5eB94bcf746C8FCcb312a722c9B" as Address,
   abi: [
-    {
-      inputs: [],
-      name: "AccessControlBadConfirmation",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          internalType: "bytes32",
-          name: "neededRole",
-          type: "bytes32",
-        },
-      ],
-      name: "AccessControlUnauthorizedAccount",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "InvalidInitialization",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "NotInitializing",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "owner",
-          type: "address",
-        },
-      ],
-      name: "OwnableInvalidOwner",
-      type: "error",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "OwnableUnauthorizedAccount",
-      type: "error",
-    },
-    {
-      inputs: [],
-      name: "ReentrancyGuardReentrantCall",
-      type: "error",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: false,
-          internalType: "uint64",
-          name: "version",
-          type: "uint64",
-        },
-      ],
-      name: "Initialized",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "address",
-          name: "previousOwner",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "OwnershipTransferStarted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "address",
-          name: "previousOwner",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "OwnershipTransferred",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "previousAdminRole",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "newAdminRole",
-          type: "bytes32",
-        },
-      ],
-      name: "RoleAdminChanged",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "RoleGranted",
-      type: "event",
-    },
-    {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: true,
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "sender",
-          type: "address",
-        },
-      ],
-      name: "RoleRevoked",
-      type: "event",
-    },
-    {
-      inputs: [],
-      name: "DEFAULT_ADMIN_ROLE",
-      outputs: [
-        {
-          internalType: "bytes32",
-          name: "",
-          type: "bytes32",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "acceptOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_txId",
-          type: "bytes32",
-        },
-        {
-          internalType: "uint256",
-          name: "_currentTimestamp",
-          type: "uint256",
-        },
-      ],
-      name: "canFinalize",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "consensusMain",
-      outputs: [
-        {
-          internalType: "contract IConsensusMain",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getLastAppealResult",
-      outputs: [
-        {
-          internalType: "enum ITransactions.ResultType",
-          name: "",
-          type: "uint8",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestAcceptedTransaction",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData",
-          name: "txData",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "startIndex",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "pageSize",
-          type: "uint256",
-        },
-      ],
-      name: "getLatestAcceptedTransactions",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData[]",
-          name: "",
-          type: "tuple[]",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestAcceptedTxCount",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestFinalizedTransaction",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData",
-          name: "txData",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "startIndex",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "pageSize",
-          type: "uint256",
-        },
-      ],
-      name: "getLatestFinalizedTransactions",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData[]",
-          name: "",
-          type: "tuple[]",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestFinalizedTxCount",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestPendingTxCount",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "slot",
-          type: "uint256",
-        },
-      ],
-      name: "getLatestPendingTxId",
-      outputs: [
-        {
-          internalType: "bytes32",
-          name: "",
-          type: "bytes32",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestUndeterminedTransaction",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData",
-          name: "txData",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-      ],
-      name: "getLatestUndeterminedTxCount",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getMessagesForTransaction",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "enum IMessages.MessageType",
-              name: "messageType",
-              type: "uint8",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "value",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes",
-              name: "data",
-              type: "bytes",
-            },
-            {
-              internalType: "bool",
-              name: "onAcceptance",
-              type: "bool",
-            },
-          ],
-          internalType: "struct IMessages.SubmittedMessage[]",
-          name: "",
-          type: "tuple[]",
-        },
-        {
-          internalType: "address",
-          name: "ghostAddress",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "numOfMessagesIssuedOnAcceptance",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "numOfMessagesIssuedOnFinalization",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getReadStateBlockRangeForTransaction",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "activationBlock",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "processingBlock",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "proposalBlock",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          internalType: "uint256",
-          name: "startIndex",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "endIndex",
-          type: "uint256",
-        },
-      ],
-      name: "getRecipientQueues",
-      outputs: [
-        {
-          components: [
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "head",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "tail",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "txIds",
-                  type: "bytes32[]",
-                },
-              ],
-              internalType: "struct IQueues.QueueInfoView",
-              name: "pending",
-              type: "tuple",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "head",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "tail",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "txIds",
-                  type: "bytes32[]",
-                },
-              ],
-              internalType: "struct IQueues.QueueInfoView",
-              name: "accepted",
-              type: "tuple",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "head",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "tail",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "txIds",
-                  type: "bytes32[]",
-                },
-              ],
-              internalType: "struct IQueues.QueueInfoView",
-              name: "undetermined",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "finalizedCount",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "issuedTxCount",
-              type: "uint256",
-            },
-          ],
-          internalType: "struct IQueues.RecipientQueuesView",
-          name: "",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-      ],
-      name: "getRoleAdmin",
-      outputs: [
-        {
-          internalType: "bytes32",
-          name: "",
-          type: "bytes32",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "getTotalNumOfTransactions",
-      outputs: [
-        {
-          internalType: "uint256",
-          name: "",
-          type: "uint256",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getTransactionAllData",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "bytes32",
-              name: "id",
-              type: "bytes32",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "previousStatus",
-              type: "uint8",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "created",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "pending",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "activated",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "committed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "lastVote",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealSubmitted",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.Timestamps",
-              name: "timestamps",
-              type: "tuple",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "bool",
-              name: "onAcceptanceMessages",
-              type: "bool",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "address[]",
-              name: "consumedValidators",
-              type: "address[]",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData[]",
-              name: "roundData",
-              type: "tuple[]",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfMessagesIssuedOnAcceptance",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfMessagesIssuedOnFinalization",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "txOrigin",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "initialRotations",
-              type: "uint256",
-            },
-          ],
-          internalType: "struct ITransactions.Transaction",
-          name: "transaction",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-        {
-          internalType: "uint256",
-          name: "_timestamp",
-          type: "uint256",
-        },
-      ],
-      name: "getTransactionData",
-      outputs: [
-        {
-          components: [
-            {
-              internalType: "uint256",
-              name: "currentTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "sender",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "recipient",
-              type: "address",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfInitialValidators",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "txSlot",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "createdTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "uint256",
-              name: "lastVoteTimestamp",
-              type: "uint256",
-            },
-            {
-              internalType: "bytes32",
-              name: "randomSeed",
-              type: "bytes32",
-            },
-            {
-              internalType: "enum ITransactions.ResultType",
-              name: "result",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes",
-              name: "txData",
-              type: "bytes",
-            },
-            {
-              internalType: "bytes",
-              name: "txReceipt",
-              type: "bytes",
-            },
-            {
-              components: [
-                {
-                  internalType: "enum IMessages.MessageType",
-                  name: "messageType",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address",
-                  name: "recipient",
-                  type: "address",
-                },
-                {
-                  internalType: "uint256",
-                  name: "value",
-                  type: "uint256",
-                },
-                {
-                  internalType: "bytes",
-                  name: "data",
-                  type: "bytes",
-                },
-                {
-                  internalType: "bool",
-                  name: "onAcceptance",
-                  type: "bool",
-                },
-              ],
-              internalType: "struct IMessages.SubmittedMessage[]",
-              name: "messages",
-              type: "tuple[]",
-            },
-            {
-              internalType: "enum IQueues.QueueType",
-              name: "queueType",
-              type: "uint8",
-            },
-            {
-              internalType: "uint256",
-              name: "queuePosition",
-              type: "uint256",
-            },
-            {
-              internalType: "address",
-              name: "activator",
-              type: "address",
-            },
-            {
-              internalType: "address",
-              name: "lastLeader",
-              type: "address",
-            },
-            {
-              internalType: "enum ITransactions.TransactionStatus",
-              name: "status",
-              type: "uint8",
-            },
-            {
-              internalType: "bytes32",
-              name: "txId",
-              type: "bytes32",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "activationBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "processingBlock",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "proposalBlock",
-                  type: "uint256",
-                },
-              ],
-              internalType: "struct ITransactions.ReadStateBlockRange",
-              name: "readStateBlockRange",
-              type: "tuple",
-            },
-            {
-              internalType: "uint256",
-              name: "numOfRounds",
-              type: "uint256",
-            },
-            {
-              components: [
-                {
-                  internalType: "uint256",
-                  name: "round",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "leaderIndex",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesCommitted",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "votesRevealed",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "appealBond",
-                  type: "uint256",
-                },
-                {
-                  internalType: "uint256",
-                  name: "rotationsLeft",
-                  type: "uint256",
-                },
-                {
-                  internalType: "enum ITransactions.ResultType",
-                  name: "result",
-                  type: "uint8",
-                },
-                {
-                  internalType: "address[]",
-                  name: "roundValidators",
-                  type: "address[]",
-                },
-                {
-                  internalType: "bytes32[]",
-                  name: "validatorVotesHash",
-                  type: "bytes32[]",
-                },
-                {
-                  internalType: "enum ITransactions.VoteType[]",
-                  name: "validatorVotes",
-                  type: "uint8[]",
-                },
-              ],
-              internalType: "struct ITransactions.RoundData",
-              name: "lastRound",
-              type: "tuple",
-            },
-          ],
-          internalType: "struct ConsensusData.TransactionData",
-          name: "",
-          type: "tuple",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "uint256",
-          name: "startIndex",
-          type: "uint256",
-        },
-        {
-          internalType: "uint256",
-          name: "endIndex",
-          type: "uint256",
-        },
-      ],
-      name: "getTransactionIndexToTxId",
-      outputs: [
-        {
-          internalType: "bytes32[]",
-          name: "",
-          type: "bytes32[]",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-        {
-          internalType: "uint256",
-          name: "_timestamp",
-          type: "uint256",
-        },
-      ],
-      name: "getTransactionStatus",
-      outputs: [
-        {
-          internalType: "enum ITransactions.TransactionStatus",
-          name: "",
-          type: "uint8",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getValidatorsForLastAppeal",
-      outputs: [
-        {
-          internalType: "address[]",
-          name: "",
-          type: "address[]",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "getValidatorsForLastRound",
-      outputs: [
-        {
-          internalType: "address[]",
-          name: "",
-          type: "address[]",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "grantRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "hasRole",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "hasTransactionOnAcceptanceMessages",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "_tx_id",
-          type: "bytes32",
-        },
-      ],
-      name: "hasTransactionOnFinalizationMessages",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_consensusMain",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_transactions",
-          type: "address",
-        },
-        {
-          internalType: "address",
-          name: "_queues",
-          type: "address",
-        },
-      ],
-      name: "initialize",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "owner",
-      outputs: [
-        {
-          internalType: "address",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "pendingOwner",
-      outputs: [
-        {
-          internalType: "address",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "queues",
-      outputs: [
-        {
-          internalType: "contract IQueues",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "renounceOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "callerConfirmation",
-          type: "address",
-        },
-      ],
-      name: "renounceRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes32",
-          name: "role",
-          type: "bytes32",
-        },
-        {
-          internalType: "address",
-          name: "account",
-          type: "address",
-        },
-      ],
-      name: "revokeRole",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_consensusMain",
-          type: "address",
-        },
-      ],
-      name: "setConsensusMain",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_queues",
-          type: "address",
-        },
-      ],
-      name: "setQueues",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "_transactions",
-          type: "address",
-        },
-      ],
-      name: "setTransactions",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "bytes4",
-          name: "interfaceId",
-          type: "bytes4",
-        },
-      ],
-      name: "supportsInterface",
-      outputs: [
-        {
-          internalType: "bool",
-          name: "",
-          type: "bool",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [],
-      name: "transactions",
-      outputs: [
-        {
-          internalType: "contract ITransactions",
-          name: "",
-          type: "address",
-        },
-      ],
-      stateMutability: "view",
-      type: "function",
-    },
-    {
-      inputs: [
-        {
-          internalType: "address",
-          name: "newOwner",
-          type: "address",
-        },
-      ],
-      name: "transferOwnership",
-      outputs: [],
-      stateMutability: "nonpayable",
-      type: "function",
-    },
-  ],
+  {
+    "inputs": [],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "addressManager",
+    "outputs": [
+      {
+        "internalType": "contract IAddressManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_currentTimestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "canFinalize",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "getLatestAcceptedTransaction",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "currentTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastVoteTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum IQueues.QueueType",
+            "name": "queueType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "queuePosition",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "lastLeader",
+            "type": "address"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange",
+            "name": "readStateBlockRange",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfRounds",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "round",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "leaderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesCommitted",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesRevealed",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "appealBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "rotationsLeft",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum ITransactions.ResultType",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address[]",
+                "name": "roundValidators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "enum ITransactions.VoteType[]",
+                "name": "validatorVotes",
+                "type": "uint8[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorVotesHash",
+                "type": "bytes32[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorResultHash",
+                "type": "bytes32[]"
+              }
+            ],
+            "internalType": "struct ITransactions.RoundData",
+            "name": "lastRound",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address[]",
+            "name": "consumedValidators",
+            "type": "address[]"
+          }
+        ],
+        "internalType": "struct ConsensusData.TransactionData",
+        "name": "inputData",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pageSize",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLatestAcceptedTransactions",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "currentTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastVoteTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum IQueues.QueueType",
+            "name": "queueType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "queuePosition",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "lastLeader",
+            "type": "address"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange",
+            "name": "readStateBlockRange",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfRounds",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "round",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "leaderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesCommitted",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesRevealed",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "appealBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "rotationsLeft",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum ITransactions.ResultType",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address[]",
+                "name": "roundValidators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "enum ITransactions.VoteType[]",
+                "name": "validatorVotes",
+                "type": "uint8[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorVotesHash",
+                "type": "bytes32[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorResultHash",
+                "type": "bytes32[]"
+              }
+            ],
+            "internalType": "struct ITransactions.RoundData",
+            "name": "lastRound",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address[]",
+            "name": "consumedValidators",
+            "type": "address[]"
+          }
+        ],
+        "internalType": "struct ConsensusData.TransactionData[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "getLatestAcceptedTxCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "getLatestFinalizedTransaction",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "currentTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastVoteTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum IQueues.QueueType",
+            "name": "queueType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "queuePosition",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "lastLeader",
+            "type": "address"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange",
+            "name": "readStateBlockRange",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfRounds",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "round",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "leaderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesCommitted",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesRevealed",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "appealBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "rotationsLeft",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum ITransactions.ResultType",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address[]",
+                "name": "roundValidators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "enum ITransactions.VoteType[]",
+                "name": "validatorVotes",
+                "type": "uint8[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorVotesHash",
+                "type": "bytes32[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorResultHash",
+                "type": "bytes32[]"
+              }
+            ],
+            "internalType": "struct ITransactions.RoundData",
+            "name": "lastRound",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address[]",
+            "name": "consumedValidators",
+            "type": "address[]"
+          }
+        ],
+        "internalType": "struct ConsensusData.TransactionData",
+        "name": "inputData",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pageSize",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLatestFinalizedTransactions",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "currentTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastVoteTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum IQueues.QueueType",
+            "name": "queueType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "queuePosition",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "lastLeader",
+            "type": "address"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange",
+            "name": "readStateBlockRange",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfRounds",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "round",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "leaderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesCommitted",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesRevealed",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "appealBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "rotationsLeft",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum ITransactions.ResultType",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address[]",
+                "name": "roundValidators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "enum ITransactions.VoteType[]",
+                "name": "validatorVotes",
+                "type": "uint8[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorVotesHash",
+                "type": "bytes32[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorResultHash",
+                "type": "bytes32[]"
+              }
+            ],
+            "internalType": "struct ITransactions.RoundData",
+            "name": "lastRound",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address[]",
+            "name": "consumedValidators",
+            "type": "address[]"
+          }
+        ],
+        "internalType": "struct ConsensusData.TransactionData[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "getLatestFinalizedTxCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getTransactionAllData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum ITransactions.VoteType",
+            "name": "txExecutionResult",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "previousStatus",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "txOrigin",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfInitialValidators",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "epoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "resultHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange[]",
+            "name": "readStateBlockRanges",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "validUntil",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lockedStorageUnitPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "storageFeeUsed",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ITransactions.Transaction",
+        "name": "transaction",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "round",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "leaderIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votesCommitted",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votesRevealed",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "appealBond",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rotationsLeft",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address[]",
+            "name": "roundValidators",
+            "type": "address[]"
+          },
+          {
+            "internalType": "enum ITransactions.VoteType[]",
+            "name": "validatorVotes",
+            "type": "uint8[]"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "validatorVotesHash",
+            "type": "bytes32[]"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "validatorResultHash",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct ITransactions.RoundData[]",
+        "name": "roundsData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTransactionData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "currentTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialRotations",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "txSlot",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastVoteTimestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "randomSeed",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.ResultType",
+            "name": "result",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "txCalldata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "eqBlocksOutputs",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum IQueues.QueueType",
+            "name": "queueType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "queuePosition",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "activator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "lastLeader",
+            "type": "address"
+          },
+          {
+            "internalType": "enum ITransactions.TransactionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "activationBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "processingBlock",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "proposalBlock",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ITransactions.ReadStateBlockRange",
+            "name": "readStateBlockRange",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "numOfRounds",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "round",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "leaderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesCommitted",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "votesRevealed",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "appealBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "rotationsLeft",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum ITransactions.ResultType",
+                "name": "result",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address[]",
+                "name": "roundValidators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "enum ITransactions.VoteType[]",
+                "name": "validatorVotes",
+                "type": "uint8[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorVotesHash",
+                "type": "bytes32[]"
+              },
+              {
+                "internalType": "bytes32[]",
+                "name": "validatorResultHash",
+                "type": "bytes32[]"
+              }
+            ],
+            "internalType": "struct ITransactions.RoundData",
+            "name": "lastRound",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address[]",
+            "name": "consumedValidators",
+            "type": "address[]"
+          }
+        ],
+        "internalType": "struct ConsensusData.TransactionData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTransactionStatus",
+    "outputs": [
+      {
+        "internalType": "enum ITransactions.TransactionStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getValidatorsForLastRound",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "validators",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressManager",
+        "type": "address"
+      }
+    ],
+    "name": "setAddressManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+],
   bytecode: "",
 };
 
@@ -4007,9 +3389,9 @@ export const testnetAsimov: GenLayerChain = defineChain({
   consensusMainContract: CONSENSUS_MAIN_CONTRACT,
   consensusDataContract: CONSENSUS_DATA_CONTRACT,
   stakingContract: STAKING_CONTRACT,
-  feeManagerContract: null,
-  roundsStorageContract: null,
-  appealsContract: null,
+  feeManagerContract: FEE_MANAGER_CONTRACT,
+  roundsStorageContract: ROUNDS_STORAGE_CONTRACT,
+  appealsContract: APPEALS_CONTRACT,
   defaultNumberOfInitialValidators: 5,
   defaultConsensusMaxRotations: 3,
 });

--- a/src/chains/testnetBradbury.ts
+++ b/src/chains/testnetBradbury.ts
@@ -21,7 +21,9 @@ const FEE_MANAGER_CONTRACT = {
         { name: "_round", type: "uint256" },
         { name: "_status", type: "uint8" },
       ],
-      outputs: [{ name: "totalFeesToPay", type: "uint256" }],
+      outputs: [
+        { name: "totalFeesToPay", type: "uint256" },
+      ],
     },
   ],
 };
@@ -30,23 +32,17 @@ const ROUNDS_STORAGE_CONTRACT = {
   abi: [
     {
       type: "function" as const,
-      name: "getRoundNumber",
-      stateMutability: "view" as const,
-      inputs: [{ name: "_txId", type: "bytes32" }],
-      outputs: [{ name: "", type: "uint256" }],
-    },
-    {
-      type: "function" as const,
-      name: "getRoundData",
+      name: "getLastRoundData",
       stateMutability: "view" as const,
       inputs: [
-        { name: "_txId", type: "bytes32" },
-        { name: "_round", type: "uint256" },
+        { name: "txId", type: "bytes32" },
       ],
-      outputs: [{
-        name: "",
-        type: "tuple",
-        components: [
+      outputs: [
+        { name: "round", type: "uint256" },
+        {
+          name: "roundData",
+          type: "tuple",
+          components: [
           { name: "round", type: "uint256" },
           { name: "leaderIndex", type: "uint256" },
           { name: "votesCommitted", type: "uint256" },
@@ -58,33 +54,47 @@ const ROUNDS_STORAGE_CONTRACT = {
           { name: "validatorVotes", type: "uint8[]" },
           { name: "validatorVotesHash", type: "bytes32[]" },
           { name: "validatorResultHash", type: "bytes32[]" },
-        ],
-      }],
+          ],
+        },
+      ],
     },
     {
       type: "function" as const,
-      name: "getLastRoundData",
+      name: "getRoundData",
       stateMutability: "view" as const,
-      inputs: [{ name: "_txId", type: "bytes32" }],
+      inputs: [
+        { name: "txId", type: "bytes32" },
+        { name: "round", type: "uint256" },
+      ],
       outputs: [
-        { name: "", type: "uint256" },
         {
           name: "",
           type: "tuple",
           components: [
-            { name: "round", type: "uint256" },
-            { name: "leaderIndex", type: "uint256" },
-            { name: "votesCommitted", type: "uint256" },
-            { name: "votesRevealed", type: "uint256" },
-            { name: "appealBond", type: "uint256" },
-            { name: "rotationsLeft", type: "uint256" },
-            { name: "result", type: "uint8" },
-            { name: "roundValidators", type: "address[]" },
-            { name: "validatorVotes", type: "uint8[]" },
-            { name: "validatorVotesHash", type: "bytes32[]" },
-            { name: "validatorResultHash", type: "bytes32[]" },
+          { name: "round", type: "uint256" },
+          { name: "leaderIndex", type: "uint256" },
+          { name: "votesCommitted", type: "uint256" },
+          { name: "votesRevealed", type: "uint256" },
+          { name: "appealBond", type: "uint256" },
+          { name: "rotationsLeft", type: "uint256" },
+          { name: "result", type: "uint8" },
+          { name: "roundValidators", type: "address[]" },
+          { name: "validatorVotes", type: "uint8[]" },
+          { name: "validatorVotesHash", type: "bytes32[]" },
+          { name: "validatorResultHash", type: "bytes32[]" },
           ],
         },
+      ],
+    },
+    {
+      type: "function" as const,
+      name: "getRoundNumber",
+      stateMutability: "view" as const,
+      inputs: [
+        { name: "txId", type: "bytes32" },
+      ],
+      outputs: [
+        { name: "", type: "uint256" },
       ],
     },
   ],
@@ -96,8 +106,12 @@ const APPEALS_CONTRACT = {
       type: "function" as const,
       name: "canAppeal",
       stateMutability: "view" as const,
-      inputs: [{ name: "_txId", type: "bytes32" }],
-      outputs: [{ name: "", type: "bool" }],
+      inputs: [
+        { name: "_txId", type: "bytes32" },
+      ],
+      outputs: [
+        { name: "", type: "bool" },
+      ],
     },
   ],
 };
@@ -117,17 +131,7 @@ const CONSENSUS_MAIN_CONTRACT = {
   },
   {
     "inputs": [],
-    "name": "CanNotAppeal",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "InvalidDeploymentWithSalt",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidGhostContract",
     "type": "error"
   },
   {
@@ -175,6 +179,16 @@ const CONSENSUS_MAIN_CONTRACT = {
   {
     "inputs": [],
     "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransactionNotFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
     "type": "error"
   },
   {
@@ -627,48 +641,17 @@ const CONSENSUS_MAIN_CONTRACT = {
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "tribunalIndex",
+        "name": "totalUnissuedValue",
         "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      }
-    ],
-    "name": "TribunalAppealVoteCommitted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "txId",
-        "type": "bytes32"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "tribunalIndex",
+        "name": "unissuedCount",
         "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "enum ITransactions.VoteType",
-        "name": "voteType",
-        "type": "uint8"
       }
     ],
-    "name": "TribunalAppealVoteRevealed",
+    "name": "UnissuedMessagesAtFinalization",
     "type": "event"
   },
   {
@@ -905,29 +888,6 @@ const CONSENSUS_MAIN_CONTRACT = {
       }
     ],
     "name": "cancelTransaction",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_txId",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_tribunalIndex",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "_commitHash",
-        "type": "bytes32"
-      }
-    ],
-    "name": "commitTribunalAppealVote",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1262,6 +1222,19 @@ const CONSENSUS_MAIN_CONTRACT = {
   {
     "inputs": [
       {
+        "internalType": "address[]",
+        "name": "affectedRecipients",
+        "type": "address[]"
+      }
+    ],
+    "name": "promoteNextPendingTransactions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "_txId",
         "type": "bytes32"
@@ -1326,44 +1299,6 @@ const CONSENSUS_MAIN_CONTRACT = {
   {
     "inputs": [],
     "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_txId",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_tribunalIndex",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "_voteHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "enum ITransactions.VoteType",
-        "name": "_voteType",
-        "type": "uint8"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "_otherExecutionFieldsHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_nonce",
-        "type": "uint256"
-      }
-    ],
-    "name": "revealTribunalAppealVote",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2884,6 +2819,16 @@ const CONSENSUS_DATA_CONTRACT = {
           {
             "internalType": "uint256",
             "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lockedStorageUnitPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "storageFeeUsed",
             "type": "uint256"
           }
         ],


### PR DESCRIPTION
## Summary

Both chain configs had drifted from the current contracts in [genlayer-networks](https://github.com/genlayerlabs/genlayer-networks). Regenerate `CONSENSUS_MAIN_CONTRACT.abi` and `CONSENSUS_DATA_CONTRACT.abi` for both chains from `genlayer-networks/main`, and for Asimov wire in the previously-`null` `feeManagerContract` / `roundsStorageContract` / `appealsContract`.

### testnetAsimov (critical — actively broken)
- `TransactionLeaderTimeout` was declared with param name `tx_id`; the deployed contract emits `txId`. `appealTransaction` crashed with `TypeError: undefined is not an object (evaluating 'value.length')` inside `encodeFunctionData` because args decoded from logs landed on the wrong key.
- `feeManagerContract` / `roundsStorageContract` / `appealsContract` were `null`, though Asimov (phase5) has live deployments for all three. `appealTransaction` without an explicit `value` could not compute the min appeal bond.
- Regenerate full ABIs; wire the three previously-null contracts with addresses from `asimov/testnet_deployments.json.deployment_asimov_phase5` and narrow ABIs matching Bradbury's shape.

### testnetBradbury (drift cleanup)
- `ConsensusMain`: upstream removed the Tribunal-appeal surface (`TribunalAppealVoteCommitted` / `Revealed` events, `commitTribunalAppealVote` / `revealTribunalAppealVote` functions, `CanNotAppeal` / `InvalidGhostContract` errors) and added finalization machinery (`promoteNextPendingTransactions`, `UnissuedMessagesAtFinalization`, `TransactionNotFinalized` / `Unauthorized`).
- `ConsensusData.getTransactionAllData` gained two extra `uint256` fields in its return tuple.
- Regenerate full ABIs. Addresses and narrow ABIs unchanged.

## Background
Surfaced while building an appeal agent on Bradbury + Asimov: Bradbury appeared to work, Asimov crashed on the first observed event. Both chains run the same genlayer-consensus snapshot (`48a0b66`) per `genlayer-networks`, so the divergence was purely in the SDK. Regenerating from `genlayer-networks/main` pulls in subsequent ABI cleanups that Bradbury had also missed.

A follow-up PR will add a CI drift check so this cannot happen silently again.

## Test plan
- [x] `npm test` — 41 passed
- [x] `npm run build` — tsup CJS+ESM+DTS build succeeds
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/chains/testnet{Asimov,Bradbury}.ts` — clean
- [x] Grep confirms no `tx_id` / `_tx_id` / `tx_ids` remain in either file or the rebuilt dist
- [x] (Preview of the follow-up drift check) both chain files match `genlayer-networks/main` after this change
