### PR TITLE
chore(ci): add chain configs drift check against genlayer-networks

### DIFF
--- a/.github/workflows/chains-drift.yml
+++ b/.github/workflows/chains-drift.yml
@@ -1,0 +1,36 @@
+name: Chains Drift Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Daily at 07:00 UTC. Catches upstream contract deployments even when no
+    # PRs are open against the SDK.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check chain configs against genlayer-networks
+        run: npm run check:chains

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:smoke": "vitest run --config vitest.smoke.config.ts",
     "test:watch": "vitest --watch",
     "lint": "eslint . --fix --ext .ts",
+    "check:chains": "node scripts/check-chains-drift.mjs",
     "release": "release-it --ci",
     "docs": "node scripts/generate-api-docs.mjs"
   },

--- a/scripts/check-chains-drift.mjs
+++ b/scripts/check-chains-drift.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+// Drift check: compare src/chains/testnet{Asimov,Bradbury}.ts against the
+// current contract artifacts on github.com/genlayerlabs/genlayer-networks
+// (default branch). Fires when genlayer-js has diverged from upstream — e.g.
+// when a new contract has been deployed or an ABI has changed on-chain and
+// this SDK has not been updated yet.
+//
+// - Addresses must match exactly (case-insensitive).
+// - For contracts where genlayer-js bundles the full ABI (ConsensusMain,
+//   ConsensusData) the canonical signature set must match exactly.
+// - For contracts where genlayer-js bundles a narrow ABI (FeeManager,
+//   RoundsStorage, Appeals) every entry in the narrow ABI must also exist
+//   in genlayer-networks with a matching signature — i.e. the narrow ABI
+//   must be a subset of the on-chain ABI.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const NETWORKS_REF = process.env.GENLAYER_NETWORKS_REF || "main";
+const NETWORKS_BASE = `https://raw.githubusercontent.com/genlayerlabs/genlayer-networks/${NETWORKS_REF}`;
+
+const CHAINS = [
+  { name: "asimov", deploymentKey: "deployment_asimov_phase5" },
+  { name: "bradbury", deploymentKey: "deployment_bradbury" },
+];
+
+// For each contract: where to find the ABI in genlayer-networks and whether
+// genlayer-js bundles the full ABI or a narrow (subset) ABI.
+const CONTRACTS = [
+  {
+    jsKey: "consensusMainContract",
+    networksKey: "ConsensusMain",
+    abiPath: "abi/ConsensusMain.sol/ConsensusMain.json",
+    mode: "full",
+  },
+  {
+    jsKey: "consensusDataContract",
+    networksKey: "ConsensusData",
+    abiPath: "abi/ConsensusData.sol/ConsensusData.json",
+    mode: "full",
+  },
+  {
+    jsKey: "feeManagerContract",
+    networksKey: "FeeManager",
+    abiPath: "abi/FeeManager.sol/FeeManager.json",
+    mode: "narrow",
+  },
+  {
+    jsKey: "roundsStorageContract",
+    networksKey: "RoundsStorage",
+    abiPath: "abi/transactions/RoundsStorage.sol/RoundsStorage.json",
+    mode: "narrow",
+  },
+  {
+    jsKey: "appealsContract",
+    networksKey: "Appeals",
+    abiPath: "abi/transactions/Appeals.sol/Appeals.json",
+    mode: "narrow",
+  },
+];
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status}`);
+  return res.json();
+}
+
+// Canonical signature: selectors depend on (type, name, input types), not
+// parameter names or internalType. Events are keyed by topic hash, which
+// depends on (name, input types, indexed flags). Using these as set keys
+// lets us compare ABIs without being sensitive to naming/ordering.
+function canonicalize(entry) {
+  const types = (xs) =>
+    (xs || [])
+      .map((x) => {
+        if (x.type === "tuple" || x.type === "tuple[]") {
+          return `${x.type}(${types(x.components)})`;
+        }
+        return x.type;
+      })
+      .join(",");
+  switch (entry.type) {
+    case "function":
+      return `fn:${entry.name}(${types(entry.inputs)})->${types(
+        entry.outputs,
+      )}:${entry.stateMutability}`;
+    case "event": {
+      const inputs = (entry.inputs || [])
+        .map((i) => `${i.indexed ? "indexed " : ""}${i.type}`)
+        .join(",");
+      return `event:${entry.name}(${inputs})`;
+    }
+    case "error":
+      return `error:${entry.name}(${types(entry.inputs)})`;
+    case "constructor":
+      return `constructor(${types(entry.inputs)})`;
+    case "fallback":
+      return `fallback:${entry.stateMutability}`;
+    case "receive":
+      return `receive:${entry.stateMutability}`;
+    default:
+      return `${entry.type}:${entry.name || ""}`;
+  }
+}
+
+const canonicalSet = (abi) => new Set((abi || []).map(canonicalize));
+
+function diffSets(jsSet, nwSet, mode) {
+  const missing = [...jsSet].filter((s) => !nwSet.has(s));
+  const extra = mode === "full" ? [...nwSet].filter((s) => !jsSet.has(s)) : [];
+  return { missing, extra };
+}
+
+// Load the chain objects from the built output. Running against dist/ keeps
+// this script tooling-light (no tsx/ts-node dep) and matches exactly what
+// consumers import.
+async function loadChains() {
+  const distPath = join(REPO_ROOT, "dist", "chains", "index.js");
+  try {
+    readFileSync(distPath);
+  } catch {
+    throw new Error(
+      `dist/chains/index.js not found. Run 'npm run build' before check:chains.`,
+    );
+  }
+  const mod = await import(distPath);
+  return { asimov: mod.testnetAsimov, bradbury: mod.testnetBradbury };
+}
+
+async function main() {
+  console.log(`Checking against genlayer-networks ref: ${NETWORKS_REF}`);
+  const chains = await loadChains();
+  const failures = [];
+
+  for (const { name, deploymentKey } of CHAINS) {
+    const chain = chains[name];
+    if (!chain) {
+      failures.push(`[${name}] chain export missing from dist/chains`);
+      continue;
+    }
+    const deployments = await fetchJson(
+      `${NETWORKS_BASE}/${name}/testnet_deployments.json`,
+    );
+    const group = deployments.genlayerTestnet?.[deploymentKey];
+    if (!group) {
+      failures.push(
+        `[${name}] testnet_deployments.json has no .genlayerTestnet.${deploymentKey}`,
+      );
+      continue;
+    }
+
+    for (const { jsKey, networksKey, abiPath, mode } of CONTRACTS) {
+      const jsContract = chain[jsKey];
+      if (!jsContract) {
+        failures.push(`[${name}.${jsKey}] missing in chain config`);
+        continue;
+      }
+
+      const expectedAddress = group[networksKey];
+      if (!expectedAddress) {
+        failures.push(
+          `[${name}.${jsKey}] ${networksKey} missing in deployments JSON`,
+        );
+        continue;
+      }
+      if (jsContract.address.toLowerCase() !== expectedAddress.toLowerCase()) {
+        failures.push(
+          `[${name}.${jsKey}] address drift: js=${jsContract.address} networks=${expectedAddress}`,
+        );
+      }
+
+      const nwAbi = (
+        await fetchJson(`${NETWORKS_BASE}/${name}/${abiPath}`)
+      ).abi;
+      const jsSet = canonicalSet(jsContract.abi);
+      const nwSet = canonicalSet(nwAbi);
+      const { missing, extra } = diffSets(jsSet, nwSet, mode);
+      if (missing.length) {
+        failures.push(
+          `[${name}.${jsKey}] ${missing.length} entries in genlayer-js not present in genlayer-networks:\n    ${missing.slice(0, 8).join("\n    ")}${missing.length > 8 ? `\n    …and ${missing.length - 8} more` : ""}`,
+        );
+      }
+      if (extra.length) {
+        failures.push(
+          `[${name}.${jsKey}] (full ABI) ${extra.length} entries in genlayer-networks not present in genlayer-js:\n    ${extra.slice(0, 8).join("\n    ")}${extra.length > 8 ? `\n    …and ${extra.length - 8} more` : ""}`,
+        );
+      }
+    }
+  }
+
+  if (failures.length) {
+    console.error(`\nDrift detected (${failures.length} finding(s)):\n`);
+    for (const f of failures) console.error("• " + f);
+    console.error(
+      `\ngenlayer-networks has moved ahead of this SDK. Regenerate the affected\nchain file(s) from the latest artifacts and open a PR.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    "No drift. Chain files match genlayer-networks/" + NETWORKS_REF + ".",
+  );
+}
+
+main().catch((err) => {
+  console.error("check:chains failed:", err.message || err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- Add `scripts/check-chains-drift.mjs` that diffs the bundled chain configs (addresses + ABIs for both testnets) against the current artifacts on `genlayer-networks/main`. Full-ABI contracts (ConsensusMain, ConsensusData) must match exactly; narrow-ABI contracts (FeeManager, RoundsStorage, Appeals) must be a subset. Signature canonicalization ignores parameter names / `internalType` so harmless formatting differences don't trip the check
- Add `.github/workflows/chains-drift.yml` — runs on PRs to main, pushes to main, and on a daily cron. **Blocking on PRs for now**; can be made advisory later once end-to-end tests cover the same failure modes
- Add `npm run check:chains` for local runs. Override the checked ref with `GENLAYER_NETWORKS_REF` (e.g. `GENLAYER_NETWORKS_REF=my-branch npm run check:chains`)

The script imports from the built `dist/chains/index.js` so the check sees exactly what consumers import. Requires `npm run build` first.

## Background
Follow-up to #152. After fixing the Asimov/Bradbury drift that caused real breakage (crash on `appealTransaction`), add a CI guard so it cannot happen silently again. The signal we want: "genlayer-networks has a new deployment / ABI edit that this SDK hasn't picked up yet."

Supersedes #153, which auto-closed when its base branch was deleted on the previous merge.

## Test plan
- [x] `npm run check:chains` locally — exits 0 against current `genlayer-networks/main`
- [x] Tampered locally (param name → snake_case) — exits 1 with a clean diff report
- [x] Tampered locally (address swap) — exits 1 with address drift report
- [x] Missing-dist path — prints a helpful error instead of a stack
- [ ] CI green on this PR (will confirm once pushed)
