### PR TITLE
fix(staking): route validatorDeposit/Exit via ValidatorWallet

### DIFF
--- a/src/staking/actions.ts
+++ b/src/staking/actions.ts
@@ -261,25 +261,33 @@ export const stakingActions = (
       };
     },
 
-    /** Adds additional self-stake to an active validator position. */
+    /**
+     * Adds additional self-stake to an active validator position. The
+     * underlying Staking contract requires msg.sender == ValidatorWallet,
+     * so the call is routed through the wallet's own validatorDeposit
+     * forwarder (which re-enters Staking with the correct sender).
+     */
     validatorDeposit: async (options: ValidatorDepositOptions): Promise<StakingTransactionResult> => {
       const amount = parseStakingAmount(options.amount);
       const data = encodeFunctionData({
-        abi: STAKING_ABI,
+        abi: VALIDATOR_WALLET_ABI,
         functionName: "validatorDeposit",
       });
-      return executeWrite({to: getStakingAddress(), data, value: amount});
+      return executeWrite({to: options.validator as ViemAddress, data, value: amount});
     },
 
-    /** Exits a validator position by burning the specified shares. */
+    /**
+     * Exits a validator position by burning the specified shares. Same
+     * msg.sender constraint as validatorDeposit — routed via the wallet.
+     */
     validatorExit: async (options: ValidatorExitOptions): Promise<StakingTransactionResult> => {
       const shares = typeof options.shares === "string" ? BigInt(options.shares) : options.shares;
       const data = encodeFunctionData({
-        abi: STAKING_ABI,
+        abi: VALIDATOR_WALLET_ABI,
         functionName: "validatorExit",
         args: [shares],
       });
-      return executeWrite({to: getStakingAddress(), data});
+      return executeWrite({to: options.validator as ViemAddress, data});
     },
 
     /** Claims pending validator withdrawals. */

--- a/src/types/staking.ts
+++ b/src/types/staking.ts
@@ -156,10 +156,12 @@ export interface ValidatorJoinOptions {
 
 export interface ValidatorDepositOptions {
   amount: bigint | string;
+  validator: Address;
 }
 
 export interface ValidatorExitOptions {
   shares: bigint | string;
+  validator: Address;
 }
 
 export interface ValidatorClaimOptions {


### PR DESCRIPTION
## Summary
The \`StakingActions.validatorDeposit()\` and \`validatorExit()\` methods were encoding against \`STAKING_ABI\` and sending directly to the Staking contract with the operator EOA as \`msg.sender\`. The on-chain Staking contract asserts \`msg.sender == ValidatorWallet\` on those two entry points, so every call reverted.

The fix routes both calls through the \`ValidatorWallet\` contract's own \`validatorDeposit()\` / \`validatorExit(uint256)\` forwarders (already present in \`VALIDATOR_WALLET_ABI\` at \`src/abi/staking.ts:75-96\`), which re-enter Staking with the correct sender. Same pattern already used by \`setOperator\`, \`setIdentity\`, and the other wallet-level methods.

## Breaking change
Both methods now require a \`validator: Address\` field in their options — the ValidatorWallet address returned by \`validatorJoin()\`. There is no backwards-compatible path: without the wallet address, the SDK has no way to find the right forwarder.

\`\`\`ts
// Before
await client.validatorDeposit({ amount: 10n });

// After
await client.validatorDeposit({ amount: 10n, validator: wallet });
\`\`\`

## Test plan
- [x] \`npm run build\` succeeds (types compile)
- [ ] Integration: \`validatorJoin\` → \`validatorDeposit\` → \`validatorExit\` → \`validatorClaim\` round-trip on a local stack
- [ ] Existing \`tests/smoke.test.ts\` still passes (read-only coverage only; these methods aren't exercised there)

## Related
- ci-core-e2e-runner tooling tests stub these methods with \`throw\` (\`e2e/support/tooling/js-driver.ts\`) — will remove the stubs once this PR ships.