### PR TITLE
feat(contracts): support getContractCode/Schema on non-Studio chains

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -12,7 +12,7 @@ import {
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs, type Abi} from "viem";
 import {TransactionHash} from "@/types/transactions";
-import {toJsonSafeDeep, b64ToArray} from "@/utils/jsonifier";
+import {toJsonSafeDeep, b64ToArray, arrayToB64} from "@/utils/jsonifier";
 
 /**
  * Extract hex data from a gen_call result.
@@ -35,39 +35,56 @@ function extractGenCallResult(result: unknown): `0x${string}` {
 
 export const contractActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => {
   return {
-    /** Retrieves the source code of a deployed contract. Studio only. */
+    /** Retrieves the source code of a deployed contract. */
     getContractCode: async (address: Address): Promise<string> => {
-      if (!client.chain.isStudio) {
-        throw new Error(`getContractCode is only available on Studio networks (current chain: ${client.chain.name})`);
-      }
+      const params = (client.chain.isStudio ? [address] : [{address}]) as
+        | [Address]
+        | [{address: Address}];
       const result = (await client.request({
         method: "gen_getContractCode",
-        params: [address],
+        params,
       })) as string;
       const codeBytes = b64ToArray(result);
       return new TextDecoder().decode(codeBytes);
     },
-    /** Gets the schema (methods and constructor) of a deployed contract. Studio only. */
+    /** Gets the schema (methods and constructor) of a deployed contract. */
     getContractSchema: async (address: Address): Promise<ContractSchema> => {
-      if (!client.chain.isStudio) {
-        throw new Error(`getContractSchema is only available on Studio networks (current chain: ${client.chain.name})`);
+      if (client.chain.isStudio) {
+        const schema = (await client.request({
+          method: "gen_getContractSchema",
+          params: [address],
+        })) as string;
+        return schema as unknown as ContractSchema;
       }
+      // Non-Studio nodes expose `gen_getContractSchema({code})` rather than a per-address lookup,
+      // so fetch the code first and ask for its schema.
+      const codeB64 = (await client.request({
+        method: "gen_getContractCode",
+        params: [{address}],
+      })) as string;
       const schema = (await client.request({
         method: "gen_getContractSchema",
-        params: [address],
-      })) as string;
-      return schema as unknown as ContractSchema;
+        params: [{code: codeB64}],
+      })) as unknown as ContractSchema;
+      return schema;
     },
-    /** Generates a schema for contract code without deploying it. Studio only. */
+    /** Generates a schema for contract code without deploying it. */
     getContractSchemaForCode: async (contractCode: string | Uint8Array): Promise<ContractSchema> => {
-      if (!client.chain.isStudio) {
-        throw new Error(`getContractSchemaForCode is only available on Studio networks (current chain: ${client.chain.name})`);
+      if (client.chain.isStudio) {
+        const schema = (await client.request({
+          method: "gen_getContractSchemaForCode",
+          params: [toHex(contractCode)],
+        })) as string;
+        return schema as unknown as ContractSchema;
       }
+      // Non-Studio nodes expose the same semantic as `gen_getContractSchema({code: <base64>})`.
+      const bytes = typeof contractCode === "string" ? new TextEncoder().encode(contractCode) : contractCode;
+      const codeB64 = arrayToB64(bytes);
       const schema = (await client.request({
-        method: "gen_getContractSchemaForCode",
-        params: [toHex(contractCode)],
-      })) as string;
-      return schema as unknown as ContractSchema;
+        method: "gen_getContractSchema",
+        params: [{code: codeB64}],
+      })) as unknown as ContractSchema;
+      return schema;
     },
     /** Executes a read-only contract call without modifying state. */
     readContract: async <RawReturn extends boolean | undefined>(args: {

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -14,9 +14,9 @@ export type GenLayerMethod =
   | {method: "eth_getTransactionByHash"; params: [hash: TransactionHash]}
   | {method: "eth_call"; params: [requestParams: any, blockNumberOrHash: string]}
   | {method: "eth_sendRawTransaction"; params: [signedTransaction: string]}
-  | {method: "gen_getContractSchema"; params: [address: Address]}
+  | {method: "gen_getContractSchema"; params: [address: Address] | [{address: Address}] | [{code: string}]}
   | {method: "gen_getContractSchemaForCode"; params: [contractCode: string]}
-  | {method: "gen_getContractCode"; params: [address: Address]}
+  | {method: "gen_getContractCode"; params: [address: Address] | [{address: Address}]}
   | {method: "sim_getTransactionsForAddress"; params: [address: Address, filter?: "all" | "from" | "to"]}
   | {method: "eth_getTransactionCount"; params: [address: Address, block: string]}
   | {method: "eth_estimateGas"; params: [transactionParams: any]}

--- a/src/utils/jsonifier.ts
+++ b/src/utils/jsonifier.ts
@@ -8,6 +8,14 @@ export function b64ToArray(b64: string): Uint8Array {
   return Uint8Array.from(atob(b64 as string), (c) => c.charCodeAt(0));
 }
 
+export function arrayToB64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export function calldataToUserFriendlyJson(cd: Uint8Array): any {
   return {
     raw: Array.from(cd),

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -518,6 +518,136 @@ const setupFinalizeHarness = ({receiptStatus = "success"}: {receiptStatus?: stri
   return {actions, signTransaction, sendRawTransaction, waitForTransactionReceipt, estimateTransactionGas, client};
 };
 
+describe("contractActions getContractCode", () => {
+  const SOURCE = '# v0.1.0\n# { "Depends": "py-genlayer:test" }\n\nfrom genlayer import *\n';
+  const SOURCE_B64 = Buffer.from(SOURCE, "utf-8").toString("base64");
+  const CONTRACT = "0x000000000000000000000000000000000000dEaD";
+
+  const buildClient = ({isStudio}: {isStudio: boolean}) => {
+    const request = vi.fn().mockResolvedValue(SOURCE_B64);
+    const client = {
+      chain: {id: isStudio ? 61_127 : 4_221, name: isStudio ? "localnet" : "Bradbury", isStudio},
+      request,
+    };
+    const actions = contractActions(client as any, {} as any);
+    return {actions, request};
+  };
+
+  it("uses positional params on Studio chains", async () => {
+    const {actions, request} = buildClient({isStudio: true});
+    const code = await actions.getContractCode(CONTRACT);
+    expect(code).toBe(SOURCE);
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractCode",
+      params: [CONTRACT],
+    });
+  });
+
+  it("uses object-shaped params on non-Studio chains", async () => {
+    const {actions, request} = buildClient({isStudio: false});
+    const code = await actions.getContractCode(CONTRACT);
+    expect(code).toBe(SOURCE);
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractCode",
+      params: [{address: CONTRACT}],
+    });
+  });
+});
+
+describe("contractActions getContractSchema", () => {
+  const SOURCE = 'from genlayer import *\n';
+  const SOURCE_B64 = Buffer.from(SOURCE, "utf-8").toString("base64");
+  const CONTRACT = "0x000000000000000000000000000000000000dEaD";
+  const SCHEMA = {ctor: {kwparams: {}, params: []}, methods: {}};
+
+  it("calls gen_getContractSchema(address) directly on Studio", async () => {
+    const request = vi.fn().mockResolvedValue(SCHEMA);
+    const client = {chain: {id: 61_127, name: "localnet", isStudio: true}, request};
+    const actions = contractActions(client as any, {} as any);
+
+    const schema = await actions.getContractSchema(CONTRACT);
+
+    expect(schema).toEqual(SCHEMA);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractSchema",
+      params: [CONTRACT],
+    });
+  });
+
+  it("fetches code then calls gen_getContractSchema({code}) on non-Studio chains", async () => {
+    const request = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "gen_getContractCode") return SOURCE_B64;
+      if (method === "gen_getContractSchema") return SCHEMA;
+      throw new Error(`Unexpected RPC method: ${method}`);
+    });
+    const client = {chain: {id: 4_221, name: "Bradbury", isStudio: false}, request};
+    const actions = contractActions(client as any, {} as any);
+
+    const schema = await actions.getContractSchema(CONTRACT);
+
+    expect(schema).toEqual(SCHEMA);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(1, {
+      method: "gen_getContractCode",
+      params: [{address: CONTRACT}],
+    });
+    expect(request).toHaveBeenNthCalledWith(2, {
+      method: "gen_getContractSchema",
+      params: [{code: SOURCE_B64}],
+    });
+  });
+});
+
+describe("contractActions getContractSchemaForCode", () => {
+  const SOURCE = 'from genlayer import *\n';
+  const SOURCE_B64 = Buffer.from(SOURCE, "utf-8").toString("base64");
+  const SOURCE_HEX = toHex(SOURCE);
+  const SCHEMA = {ctor: {kwparams: {}, params: []}, methods: {}};
+
+  it("calls gen_getContractSchemaForCode with hex-encoded code on Studio", async () => {
+    const request = vi.fn().mockResolvedValue(SCHEMA);
+    const client = {chain: {id: 61_127, name: "localnet", isStudio: true}, request};
+    const actions = contractActions(client as any, {} as any);
+
+    const schema = await actions.getContractSchemaForCode(SOURCE);
+
+    expect(schema).toEqual(SCHEMA);
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractSchemaForCode",
+      params: [SOURCE_HEX],
+    });
+  });
+
+  it("calls gen_getContractSchema({code}) with base64-encoded code on non-Studio chains", async () => {
+    const request = vi.fn().mockResolvedValue(SCHEMA);
+    const client = {chain: {id: 4_221, name: "Bradbury", isStudio: false}, request};
+    const actions = contractActions(client as any, {} as any);
+
+    const schema = await actions.getContractSchemaForCode(SOURCE);
+
+    expect(schema).toEqual(SCHEMA);
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractSchema",
+      params: [{code: SOURCE_B64}],
+    });
+  });
+
+  it("accepts Uint8Array input and base64-encodes it on non-Studio chains", async () => {
+    const request = vi.fn().mockResolvedValue(SCHEMA);
+    const client = {chain: {id: 4_221, name: "Bradbury", isStudio: false}, request};
+    const actions = contractActions(client as any, {} as any);
+
+    const bytes = new TextEncoder().encode(SOURCE);
+    await actions.getContractSchemaForCode(bytes);
+
+    expect(request).toHaveBeenCalledWith({
+      method: "gen_getContractSchema",
+      params: [{code: SOURCE_B64}],
+    });
+  });
+});
+
 describe("contractActions finalizeTransaction", () => {
   it("encodes finalizeTransaction(bytes32) and returns EVM tx hash", async () => {
     const {actions, signTransaction, sendRawTransaction} = setupFinalizeHarness();


### PR DESCRIPTION
## Summary

Remove the hard `isStudio` guards on `getContractCode`, `getContractSchema`, and `getContractSchemaForCode`. These methods exist on the GenLayer node RPC (Bradbury / Asimov) but with different semantics and parameter shapes than Studio localnet, so the SDK now branches internally and callers no longer need to know about the divergence.

- **`getContractCode(address)`** — Studio takes `[address]` (positional), node takes `[{address}]` (object). Response is base64 in both.
- **`getContractSchema(address)`** — Studio resolves in a single RPC. Node has no per-address schema endpoint, so this now does a 2-call dance internally: `gen_getContractCode({address})` → base64 → `gen_getContractSchema({code})`.
- **`getContractSchemaForCode(code)`** — Studio calls `gen_getContractSchemaForCode` with hex-encoded code. Node calls `gen_getContractSchema({code})` with base64-encoded code.

Verified against Asimov (`https://rpc-asimov.genlayer.com`): `gen_getContractCode` and `gen_getContractSchema` both return the expected schema for `0x0E62e5f832Ac310494b9ad6aAA24F907482DEd7F` via the 2-call path.

Unblocks multi-network UIs (e.g. the Studio frontend running against Bradbury). Longer-term protocol-level alignment of Studio and node semantics is tracked separately in the Studio repo (`docs/plans/studio-testnet-format-alignment.md`); once aligned, the SDK branching here becomes unnecessary and can be simplified.

## Test plan

- [x] Unit: `tests/contracts-actions.test.ts` — 6 new tests covering Studio and non-Studio paths for all three methods, including Uint8Array input
- [x] `npm run build` clean (ESM + CJS + dts)
- [x] `npm run lint` clean
- [x] `npm test` — 49/49 pass with typecheck
- [ ] Smoke test in a downstream project after release (Studio frontend will pick up on next bump)