### PR TITLE
fix(contracts): default _validUntil to now + 1h instead of 0

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -538,10 +538,16 @@ const _encodeAddTransactionData = ({
     args: addTransactionArgs,
   });
 
+  // `_validUntil = 0` is treated as "expired" by the on-chain consensus
+  // contract, so every submission with a v6 signature would revert. Use
+  // `now + 1 hour` — enough buffer for wallet confirmation + mining, short
+  // enough that stale signed txs don't hang around forever.
+  const validUntil = BigInt(Math.floor(Date.now() / 1000) + 3600);
+
   const encodedDataV6 = encodeFunctionData({
     abi: ADD_TRANSACTION_ABI_V6 as any,
     functionName: "addTransaction",
-    args: [...addTransactionArgs, 0n],
+    args: [...addTransactionArgs, validUntil],
   });
 
   if (getAddTransactionInputCount(client.chain.consensusMainContract?.abi) >= 6) {


### PR DESCRIPTION
## Summary

The v6 \`addTransaction\` signature on the consensus contract carries a \`_validUntil\` field. The SDK was hardcoding \`0n\` for it.

Empirically on Bradbury, deploys with \`_validUntil = 0\` are mined and then reverted inside the EVM wrapper (plain \`revert()\` — no reason string). The same tx with \`_validUntil = block.timestamp + N\` succeeds end-to-end through GenLayer consensus.

The public consensus source (e.g. \`phases/IdlenessPhase.sol\`, \`ActivationPhase.sol\`, \`FinalizationPhase.sol\`) treats 0 as \"no expiry\" (\`validUntil != 0 && validUntil < block.timestamp\`), so this looks like a behavioural divergence between the deployed contract on Bradbury and the public source — I've flagged it separately with the contracts team. In the meantime, this patch unblocks users so their deploys actually land.

Default chosen: \`now + 3600\` (1 hour). Long enough for wallet confirmation and mining; short enough that stale signed txs don't hang around.

Evidence pair (Bradbury):
- Reverted (\`validUntil = 0\`): \`0xf02d44dcbd0bf71b5b16d18aa924afa6aa926d2ccbd4f5abc78859fd79d61cb8\`
- Mined + accepted (\`validUntil = now + 3600\`): \`0x26b6ad8c36417c0152bceb88a29e2b6ae4c0191b340ded2aba8bbfd0f75bf99d\`

Unblocks the Studio frontend's runtime network selector (\`genlayerlabs/genlayer-studio#1606\`).

## Test plan

- [x] \`npm test\` — 49/49 pass (existing v5/v6 selector tests still valid)
- [x] \`npm run build\` clean
- [x] Manually verified on Bradbury: deploy succeeds with the patch, reverts without it