### PR TITLE
fix(accounts): default getCurrentNonce to pending

### DIFF
--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -13,9 +13,20 @@ export function accountActions(client: GenLayerClient<GenLayerChain>) {
         params: [address, amount],
       }) as Promise<TransactionHash>;
     },
+    /**
+     * Returns the transaction count (next nonce) for an address.
+     *
+     * Defaults to `"pending"` so that rapid sequential submissions from the
+     * same account receive distinct nonces. Two submissions issued before the
+     * first confirms would otherwise both see the same `"latest"` count and
+     * collide with an "already known" or "replacement underpriced" error.
+     *
+     * Pass `block: "latest"` explicitly for confirmed-only state
+     * (e.g. reconciliation tooling comparing against on-chain finality).
+     */
     getCurrentNonce: async ({
       address,
-      block = "latest",
+      block = "pending",
     }: {
       address: Address;
       block?: string;

--- a/tests/accounts-actions.test.ts
+++ b/tests/accounts-actions.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it, vi} from "vitest";
+import {accountActions} from "../src/accounts/actions";
+
+function makeClient() {
+  const request = vi.fn().mockResolvedValue(42);
+  return {
+    client: {
+      request,
+      account: undefined,
+      chain: {id: 1},
+    } as any,
+    request,
+  };
+}
+
+describe("accountActions.getCurrentNonce", () => {
+  it("defaults to block=\"pending\" so concurrent submissions do not collide", async () => {
+    const {client, request} = makeClient();
+    const actions = accountActions(client);
+
+    await actions.getCurrentNonce({
+      address: "0x0000000000000000000000000000000000000001",
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      method: "eth_getTransactionCount",
+      params: ["0x0000000000000000000000000000000000000001", "pending"],
+    });
+  });
+
+  it("honors an explicit block override", async () => {
+    const {client, request} = makeClient();
+    const actions = accountActions(client);
+
+    await actions.getCurrentNonce({
+      address: "0x0000000000000000000000000000000000000001",
+      block: "latest",
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      method: "eth_getTransactionCount",
+      params: ["0x0000000000000000000000000000000000000001", "latest"],
+    });
+  });
+
+  it("falls back to client.account.address when address is omitted-like", async () => {
+    const request = vi.fn().mockResolvedValue(7);
+    const client = {
+      request,
+      account: {address: "0x0000000000000000000000000000000000000abc"},
+      chain: {id: 1},
+    } as any;
+    const actions = accountActions(client);
+
+    // Pass empty string, which is falsy per the implementation's fallback chain.
+    await actions.getCurrentNonce({address: "" as any});
+
+    expect(request).toHaveBeenCalledWith({
+      method: "eth_getTransactionCount",
+      params: ["0x0000000000000000000000000000000000000abc", "pending"],
+    });
+  });
+
+  it("throws when neither address nor client.account is available", async () => {
+    const {client} = makeClient();
+    const actions = accountActions(client);
+
+    await expect(actions.getCurrentNonce({address: "" as any})).rejects.toThrow(
+      /No address provided/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `getCurrentNonce` now defaults to `block: "pending"` instead of `"latest"` so rapid sequential submissions from the same account receive distinct nonces.
- Callers that still want confirmed-only state can pass `block: "latest"` explicitly.
- Adds unit coverage for the default and override paths (`tests/accounts-actions.test.ts`).

## Why

Two submissions issued before the first confirms both see the same `"latest"` count and collide — the second is rejected as `"already known"` or `"replacement underpriced"`. Every mature EVM client (viem, ethers, web3.js) defaults to `"pending"` for this reason.

This was surfaced while investigating nonce-gap hangs reported by the ZKsync team against Heartbeat. Heartbeat itself submits via viem directly (which already defaults to pending), but other SDK consumers — browser wallets, CLI tools, automation scripts — hit this every time they submit more than one tx per block.

## Test plan

- [x] `vitest run tests/accounts-actions.test.ts` — 4 new cases pass (default, override, account fallback, error)
- [x] `vitest run` — full suite (52 tests across 5 files) green, no existing test touched this default so no regressions
- [x] `tsc --noEmit` — clean

## Compatibility

Strictly safer. Any caller previously relying on `"latest"` for nonce allocation was getting incorrect behavior under concurrent submissions; this fixes it. Consumers needing the old semantic pass `block: "latest"` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * `getCurrentNonce` now defaults to querying the pending block state instead of the latest confirmed block, ensuring unconfirmed transactions are included in nonce calculations.

* **Documentation**
  * Updated function documentation to clarify the new pending-default behavior and provide guidance on when to use confirmed-only state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->