### PR TITLE
feat(fees): v2-dev bootstrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * as chains from "./chains";
 export * as abi from "./abi";
 export {parseStakingAmount, formatStakingAmount} from "./staking";
 export {buildGenVmPositionalArgs} from "./contracts/schema";
+// fees feature marker (placeholder for v2-dev fees work)


### PR DESCRIPTION
## Description

Demo PR for the version-matrix + v0.6-dev track end-to-end. Opens a \`feat/fees\` branch targeting \`v2-dev\` (the in-flight next-major line for genlayer-js).

## Triggering E2E

The auto-gate should fire immediately on PR open (pull_request event → main's workflow, which was just added). Default track is \`main\` — i.e. stable v0.5 matrix.

To test against the v0.6-dev track (fees work in the core stack), comment:

\`\`\`
/run-e2e v0.6-dev
\`\`\`

That routes to [ci-core-e2e-runner@v0.6-dev](https://github.com/genlayerlabs/ci-core-e2e-runner/tree/v0.6-dev/matrix/v0.6-dev.yaml), which pins \`genlayer-js: v2-dev\` — so this PR's branch becomes the resolved JS.

## Types of Changes

- [x] New feature (bootstrap for fees development)

## Checklist

- [x] Branch targets \`v2-dev\` (not main)
- [x] Minimal change — just a marker comment for the demo

## Expected failure modes

- Early: matrix refers to branches that don't exist yet in some tooling repos → setup-tooling clone fails with clear error.
- Otherwise: stack comes up, tests run against resolved versions.