### PR TITLE
ci: scope down release/sync-docs to dedicated GitHub Apps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,14 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: npm
+    environment: Publish
     steps:
       - name: Get CI Bot Token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: ci_bot_token
         with:
-          app_id: ${{ secrets.CI_BOT_APP_ID }}
-          private_key: ${{ secrets.CI_BOT_SECRET }}
+          client-id: ${{ vars.PUBLISH_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUBLISH_CI_APP_KEY }}
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,6 +9,7 @@ jobs:
   generate-and-sync:
     if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-')
     runs-on: ubuntu-latest
+    environment: Sync-docs
     permissions:
       contents: read
     steps:
@@ -38,9 +39,9 @@ jobs:
 
       - name: Generate docs repo token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+          client-id: ${{ vars.DOCS_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_SYNC_APP_KEY }}
           repositories: genlayer-docs
 


### PR DESCRIPTION
## Summary

Reduce the attack surface of release & docs-sync workflows by replacing the shared, over-privileged CI bot with two dedicated, minimally scoped GitHub Apps gated behind protected environments. Mirrors the same change in [genlayer-testing-suite#78](https://github.com/genlayerlabs/genlayer-testing-suite/pull/78) and [genlayer-cli#297](https://github.com/genlayerlabs/genlayer-cli/pull/297).

- **`publish.yml`** — environment renamed `npm` → `Publish`, switched from the archived `tibdex/github-app-token@v1` to the official `actions/create-github-app-token@v3`. Reads `vars.PUBLISH_CI_APP_CLIENT_ID` and `secrets.PUBLISH_CI_APP_KEY`.
- **`sync-docs.yml`** — bumped `actions/create-github-app-token` to `@v3`, switched to the explicit `client-id` parameter, gated behind the `Sync-docs` environment. Reads `vars.DOCS_SYNC_APP_CLIENT_ID` and `secrets.DOCS_SYNC_APP_KEY`. Cross-repo `repositories: genlayer-docs` token request is preserved.

Each App should be installed only on the repos it needs (Publish: this repo only; Sync-docs: this repo + `genlayer-docs`) with `Contents: Read & write` as the only permission.

## Pre-merge checklist (GitHub side)

- [ ] `Publish` environment exists with `PUBLISH_CI_APP_CLIENT_ID` (variable) and `PUBLISH_CI_APP_KEY` (secret)
- [ ] **Move/recreate the existing `NPM_TOKEN`** (or whatever release-it uses for npm publish) from the old `npm` environment into the new `Publish` environment, then delete the `npm` environment
- [ ] `Sync-docs` environment exists with `DOCS_SYNC_APP_CLIENT_ID` (variable) and `DOCS_SYNC_APP_KEY` (secret)
- [ ] Both Apps installed on `genlayer-js` (sync-docs App also on `genlayer-docs`) with only `Contents: Read & write`
- [ ] `Publish` App added to branch-protection bypass list on `main` (release-it pushes the version-bump commit + tag)
- [ ] `Sync-docs` environment "Deployment branches and tags" allows the `v*` tag pattern (otherwise `release: published` on a tag ref will be blocked)

## Test plan

- [ ] Land a `fix:` or `feat:` commit on `main` and confirm `publish.yml` mints a token, release-it pushes the version bump + tag, the GitHub Release is created, and the npm upload succeeds
- [ ] Confirm `sync-docs.yml` fires automatically on `release: published` and pushes the API-reference update to `genlayer-docs`
- [ ] Once verified, decommission the old shared CI App from this repo and rotate / revoke its secrets