### PR TITLE
ci: revert publish env name to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: Publish
+    environment: npm
     steps:
       - name: Get CI Bot Token
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Summary

Reverts the `npm` → `Publish` rename from #168. The release on `main` failed at env protection because the custom branch policy on `Publish` had a typo (`mian` instead of `main`), so the workflow never reached npm publish — but the npm trusted publisher config for this package likely pins the `environment` claim to `npm` (same root cause as in `genlayer-cli`). Reverting the env name in the workflow keeps OIDC auth working once the env is recreated.

## Pre-merge checklist (GitHub side)

- [ ] Recreate `npm` environment with:
  - Variable `PUBLISH_CI_APP_CLIENT_ID` = same value as currently in `Publish`
  - Secret `PUBLISH_CI_APP_KEY` = same value as currently in `Publish`
  - Deployment branch policy: `main` (the existing `Publish` env has a `mian` typo — do not copy it)
  - Required reviewers as desired
- [ ] Delete the `Publish` environment after the new `npm` env is in place

## Test plan

- [ ] After merge, push a `fix:` or `feat:` commit to `main` (or trigger the workflow manually) and confirm npm publish succeeds