### PR TITLE
fix(ci): verify publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Release & Publish Package to NPM
 
+# Triggered on push to main or manual dispatch.
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
No-op patch release to verify the publish pipeline end-to-end after the env scope-down and the npm trusted publisher update. Single-line comment added to publish.yml; nothing else changes.