### PR TITLE
Update genlayer-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Before installing GenLayerJS SDK, ensure you have the following prerequisites in
 
 To install the GenLayerJS SDK, use the following command:
 ```bash
-$ npm install genlayer-js
+npm install genlayer-js
 ```
 Here’s how to initialize the client and connect to the GenLayer Simulator:
 
@@ -87,7 +87,7 @@ import { localnet } from 'genlayer-js/chains';
 import { createClient, createAccount } from "genlayer-js";
 
 const client = createClient({
-  network: localnet,
+  chain: localnet,
 });
 
 const account = createAccount();


### PR DESCRIPTION
1. The installation command contains a syntax error that will prevent it from running correctly in most terminals.
​Mistake: $ npm install genlayer.js (Line 23).
​Correction: Remove the period. The package name is typically genlayer-js or simply genlayer. Based on the imports used later in the file, it should be:
​npm install genlayer-js

2. The createClient configuration uses different property names than those established in the "Reading a Transaction" section.
​Mistake: network: localnet, (Line 90).
​Correction: In all other examples (lines 33, 48, 72), the property is named chain. It should be:
​chain: localnet,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation guide with improved formatting for clarity and ease of use.
  * Updated code examples to reflect the current and recommended client initialization configuration approach.
  * Refined reference material to ensure developers have accurate guidance for integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-js/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->