### PR TITLE
fix: run CI on v1 branch

### DIFF
--- a/.github/workflows/chains-drift.yml
+++ b/.github/workflows/chains-drift.yml
@@ -3,10 +3,10 @@ name: Chains Drift Check
 on:
   pull_request:
     branches:
-      - main
+      - v1
   push:
     branches:
-      - main
+      - v1
   schedule:
     # Daily at 07:00 UTC. Catches upstream contract deployments even when no
     # PRs are open against the SDK.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Run Tests
 on:
   push:
     branches:
-      - main
+      - v1
   pull_request:
     branches:
-      - main
+      - v1
 
 jobs:
   test:

--- a/src/chains/testnetAsimov.ts
+++ b/src/chains/testnetAsimov.ts
@@ -416,6 +416,31 @@ const CONSENSUS_MAIN_CONTRACT = {
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "firstAnnouncedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewTransactionAlreadyAnnounced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
         "type": "address"

--- a/src/chains/testnetBradbury.ts
+++ b/src/chains/testnetBradbury.ts
@@ -416,6 +416,31 @@ const CONSENSUS_MAIN_CONTRACT = {
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "firstAnnouncedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewTransactionAlreadyAnnounced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
         "type": "address"


### PR DESCRIPTION
## Summary

Updates workflows that still filtered on retired `main` so they run against the current stable `v1` branch.

- `test.yml`: push and PR branch filters now target `v1`.
- `chains-drift.yml`: push and PR branch filters now target `v1`.

Publish and docs-sync release flows were already tag/release based and are unchanged.

## Verification

- `git diff --check`
- Parsed changed workflow YAML with `yq e '.'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow triggers to run on a specific branch instead of the default branch, affecting automated testing and integration processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-js/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->