### PR TITLE
feat: add v0.6 fee-aware transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,161 @@ const receipt = await client.waitForTransactionReceipt({
 
 ```
 
+### Fee presets for transactions
+
+Apps can build a trusted fee preset once they know the transaction shape, then
+submit the same preset with the transaction. The user may still override these
+values in wallet or app UI before signing.
+
+```typescript
+const estimate = await client.estimateTransactionFees({
+  leaderTimeunitsAllocation: 100n,
+  validatorTimeunitsAllocation: 200n,
+  rotations: [0n],
+});
+
+const txHash = await client.writeContract({
+  account,
+  address: contractAddress,
+  functionName: "update_storage",
+  args: ["new_storage"],
+  fees: {
+    distribution: estimate.distribution,
+    feeValue: estimate.feeValue,
+  },
+});
+```
+
+If `fees.distribution` is provided without `feeValue`, the SDK derives the fee
+deposit from FeeManager on network backends, or from `sim_getFeeConfig` on
+Studio. Use `messageAllocations` with `estimateTransactionFees` for transactions
+that can emit funded messages.
+
+Use the SDK call-key helpers when targeting a specific emitted message. Internal
+messages are keyed by the GenVM method name; external EVM messages are keyed by
+the first 4 bytes of the calldata selector.
+
+```typescript
+import {
+  MessageType,
+  deriveExternalMessageCallKey,
+  deriveInternalMessageCallKey,
+  encodeExternalMessageFeeParams,
+  encodeInternalMessageFeeParams,
+} from "genlayer-js";
+
+const estimate = await client.estimateTransactionFees({
+  messageAllocations: [
+    {
+      messageType: MessageType.Internal,
+      recipient: childContractAddress,
+      callKey: deriveInternalMessageCallKey("settle_campaign"),
+      budget: 700_000n,
+      feeParams: encodeInternalMessageFeeParams({
+        leaderTimeunitsAllocation: 100n,
+        validatorTimeunitsAllocation: 200n,
+      }),
+    },
+    {
+      messageType: MessageType.External,
+      recipient: tokenAddress,
+      callKey: deriveExternalMessageCallKey("0xa9059cbb"),
+      budget: 210_000n,
+      feeParams: encodeExternalMessageFeeParams({
+        gasLimit: 21_000n,
+        maxGasPrice: 10n,
+      }),
+    },
+  ],
+});
+```
+
+You can also pass the same preset to Studio/localnet simulation. On Studio,
+`includeReceipt` uses `sim_call` so the returned object includes the GenVM
+receipt and fee accounting report:
+
+```typescript
+const recommended = await client.estimateTransactionFeesForWrite({
+  account,
+  address: contractAddress,
+  functionName: "update_storage",
+  args: ["new_storage"],
+});
+
+await client.writeContract({
+  account,
+  address: contractAddress,
+  functionName: "update_storage",
+  args: ["new_storage"],
+  fees: {
+    distribution: recommended.distribution,
+    messageAllocations: recommended.messageAllocations,
+    feeValue: recommended.feeValue,
+  },
+});
+```
+
+For tests or tools that need to inspect the raw simulation, use the explicit
+two-step flow:
+
+```typescript
+const simulation = await client.simulateWriteContract({
+  account,
+  address: contractAddress,
+  functionName: "update_storage",
+  args: ["new_storage"],
+  fees: {
+    distribution: estimate.distribution,
+    feeValue: estimate.feeValue,
+  },
+  includeReceipt: true,
+});
+
+console.log(simulation.feeAccounting);
+
+const recommended = await client.estimateTransactionFeesFromSimulation({
+  simulation,
+});
+
+await client.writeContract({
+  account,
+  address: contractAddress,
+  functionName: "update_storage",
+  args: ["new_storage"],
+  fees: {
+    distribution: recommended.distribution,
+    messageAllocations: recommended.messageAllocations,
+    feeValue: recommended.feeValue,
+  },
+});
+```
+
+For transactions that are already submitted, use the fee-management helpers:
+
+```typescript
+await client.topUpFees({
+  txId,
+  value: 1_100n,
+  distribution: {
+    leaderTimeunitsAllocation: 100n,
+    validatorTimeunitsAllocation: 200n,
+    rotations: [0n],
+  },
+});
+
+await client.topUpAndSubmitAppeal({
+  txId,
+  value: 1_400n,
+  distribution: {
+    appealRounds: 1n,
+    rotations: [0n, 0n],
+  },
+});
+```
+
+`topUpFees` returns the backend RPC hash. On network backends this is the EVM
+transaction hash; on Studio/localnet it is the target GenLayer transaction id.
+
 ### Checking execution results
 
 A transaction can be finalized by consensus but still have a failed execution. Always check `txExecutionResult` before reading contract state:

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -9,31 +9,155 @@ import {
   CalldataEncodable,
   Address,
   TransactionHashVariant,
+  TransactionFeeOptions,
+  TransactionFeeEstimate,
+  FeeEstimateOptions,
+  SimulationFeeEstimateOptions,
+  SimulationFeeUsage,
+  WriteFeeEstimateOptions,
+  FeePolicyQuote,
+  BigNumberish,
+  FeesDistribution,
+  FeesDistributionInput,
+  MessageFeeAllocationInput,
+  MessageType,
+  SimulateWriteContractResult,
+  StudioExecutionFeeReport,
+  StudioFeeAccounting,
 } from "@/types";
 import {fromHex, toHex, zeroAddress, encodeFunctionData, PublicClient, parseEventLogs, type Abi} from "viem";
 import {TransactionHash} from "@/types/transactions";
 import {toJsonSafeDeep, b64ToArray, arrayToB64} from "@/utils/jsonifier";
+import {
+  CALL_KEY_WILDCARD,
+  createFeesDistribution,
+  MESSAGE_ALLOCATION_ROOT_PARENT_INDEX,
+  normalizeMessageFeeAllocations,
+  normalizeTransactionFees,
+  NormalizedTransactionFees,
+} from "@/transactions/fees";
+
+const prefixHex = (hex: string): `0x${string}` => {
+  return (hex.startsWith("0x") ? hex : `0x${hex}`) as `0x${string}`;
+};
 
 /**
- * Extract hex data from a gen_call result.
+ * Extract hex data from a simulation result.
  * Some RPCs return a bare hex string, others return an object like
- * { data: "hex...", status: { code, message }, ... }.
+ * { data: "hex...", status: { code, message }, ... }. Studio's `sim_call`
+ * returns the full receipt with `result` as base64-encoded GenVM result bytes,
+ * where byte 0 is the result code and the payload starts at byte 1.
  */
 function extractGenCallResult(result: unknown): `0x${string}` {
   if (typeof result === "string") {
-    return `0x${result}` as `0x${string}`;
+    return prefixHex(result);
   }
   if (result && typeof result === "object" && "data" in result) {
     const obj = result as {data: string; status?: {code: number; message: string}};
     if (obj.status && obj.status.code !== 0) {
       throw new Error(`gen_call failed: ${obj.status.message}`);
     }
-    return `0x${obj.data}` as `0x${string}`;
+    return prefixHex(obj.data);
   }
-  throw new Error(`Unexpected gen_call response: ${JSON.stringify(result)}`);
+  if (result && typeof result === "object" && "result" in result) {
+    const obj = result as {result: string; execution_result?: string};
+    if (obj.execution_result && obj.execution_result !== "SUCCESS") {
+      throw new Error(`sim_call failed: ${obj.execution_result}`);
+    }
+    if (typeof obj.result === "string" && obj.result.startsWith("0x")) {
+      return prefixHex(obj.result);
+    }
+    const resultBytes = b64ToArray(obj.result);
+    if (resultBytes.length === 0) {
+      throw new Error("sim_call returned an empty result payload");
+    }
+    return toHex(resultBytes.slice(1));
+  }
+  throw new Error(`Unexpected simulation response: ${JSON.stringify(result)}`);
+}
+
+function normalizeGenCallReceipt(result: unknown, data: `0x${string}`): Record<string, unknown> {
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return result as Record<string, unknown>;
+  }
+  return {data};
+}
+
+function extractGenCallFeeAccounting(result: unknown): StudioFeeAccounting | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return undefined;
+  const genvmResult = (result as Record<string, unknown>).genvm_result;
+  if (!genvmResult || typeof genvmResult !== "object" || Array.isArray(genvmResult)) return undefined;
+  const feeAccounting = (genvmResult as Record<string, unknown>).fee_accounting;
+  if (!feeAccounting || typeof feeAccounting !== "object" || Array.isArray(feeAccounting)) return undefined;
+  return feeAccounting as StudioFeeAccounting;
+}
+
+function extractGenCallFeeReport(feeAccounting?: StudioFeeAccounting): StudioExecutionFeeReport | undefined {
+  const report = feeAccounting?.execution_fee_report;
+  if (!report || typeof report !== "object" || Array.isArray(report)) return undefined;
+  return report;
+}
+
+function transactionFeesToRpc(fees?: TransactionFeeOptions) {
+  if (!fees) return undefined;
+  const normalized = normalizeTransactionFees(fees);
+  return {
+    distribution: {
+      leaderTimeunitsAllocation: normalized.distribution.leaderTimeunitsAllocation.toString(),
+      validatorTimeunitsAllocation: normalized.distribution.validatorTimeunitsAllocation.toString(),
+      appealRounds: normalized.distribution.appealRounds.toString(),
+      executionBudgetPerRound: normalized.distribution.executionBudgetPerRound.toString(),
+      executionConsumed: normalized.distribution.executionConsumed.toString(),
+      totalMessageFees: normalized.distribution.totalMessageFees.toString(),
+      rotations: normalized.distribution.rotations.map((rotation) => rotation.toString()),
+      maxPriceGenPerTimeUnit: normalized.distribution.maxPriceGenPerTimeUnit.toString(),
+      storageFeeMaxGasPrice: normalized.distribution.storageFeeMaxGasPrice.toString(),
+      receiptFeeMaxGasPrice: normalized.distribution.receiptFeeMaxGasPrice.toString(),
+    },
+    messageAllocations: normalized.messageAllocations.map((allocation) => ({
+      messageType: allocation.messageType,
+      onAcceptance: allocation.onAcceptance,
+      parentIndex: allocation.parentIndex.toString(),
+      recipient: allocation.recipient,
+      callKey: allocation.callKey,
+      budget: allocation.budget.toString(),
+      feeParams: allocation.feeParams,
+    })),
+    ...(normalized.feeValue === undefined ? {} : {feeValue: normalized.feeValue.toString()}),
+  };
 }
 
 export const contractActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => {
+  const estimateFeeValue = async (
+    distribution: FeesDistribution,
+    policy?: FeePolicyQuote,
+  ): Promise<bigint> => {
+    if (client.chain.feeManagerContract?.address) {
+      const roundFees = await publicClient.readContract({
+        address: client.chain.feeManagerContract.address as `0x${string}`,
+        abi: FEE_MANAGER_CALCULATE_ROUND_FEES_ABI as any,
+        functionName: "calculateRoundFees",
+        args: [
+          distribution,
+          BigInt(client.chain.defaultNumberOfInitialValidators),
+          0n,
+        ],
+      }) as bigint;
+      return roundFees + distribution.totalMessageFees;
+    }
+
+    if (client.chain.isStudio) {
+      const studioPolicy = policy ?? await readCurrentFeePolicy(client, publicClient);
+      return calculateLocalRoundFees(
+        distribution,
+        client.chain.defaultNumberOfInitialValidators,
+        studioPolicy,
+      ) + distribution.totalMessageFees;
+    }
+
+    throw new Error("Fee value estimation is not supported on this chain (missing feeManagerContract).");
+  };
+
   return {
     /** Retrieves the source code of a deployed contract. */
     getContractCode: async (address: Address): Promise<string> => {
@@ -139,22 +263,32 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       return toJsonSafeDeep(decoded) as any;
     },
     /** Simulates a state-modifying contract call without executing on-chain. */
-    simulateWriteContract: async <RawReturn extends boolean | undefined>(args: {
+    simulateWriteContract: async <
+      RawReturn extends boolean | undefined = undefined,
+      IncludeReceipt extends boolean | undefined = undefined,
+    >(args: {
       account?: Account;
       address: Address;
       functionName: string;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       rawReturn?: RawReturn;
+      includeReceipt?: IncludeReceipt;
+      value?: BigNumberish;
       leaderOnly?: boolean;
+      fees?: TransactionFeeOptions;
       transactionHashVariant?: TransactionHashVariant;
-    }): Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable> => {
+    }): Promise<IncludeReceipt extends true
+      ? SimulateWriteContractResult<RawReturn>
+      : RawReturn extends true ? `0x${string}` : CalldataEncodable> => {
       const {
         account,
         address,
         functionName,
         args: callArgs,
         kwargs,
+        value,
+        fees,
         leaderOnly = false,
         transactionHashVariant = TransactionHashVariant.LATEST_NONFINAL,
       } = args;
@@ -164,24 +298,51 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
 
       const senderAddress = account?.address ?? client.account?.address ?? zeroAddress;
 
-      const requestParams = {
+      const requestParams: Record<string, unknown> = {
         type: "write",
         to: address,
         from: senderAddress,
         data: serializedData,
         transaction_hash_variant: transactionHashVariant,
       };
+      const userValue = toUInt(value, "value", 0n);
+      if (userValue > 0n) {
+        requestParams.value = toHex(userValue);
+      }
+      const rpcFees = transactionFeesToRpc(fees);
+      if (rpcFees) {
+        requestParams.fees = rpcFees;
+      }
+      const simulationMethod = args.includeReceipt && client.chain.isStudio ? "sim_call" : "gen_call";
       const result = await client.request({
-        method: "gen_call",
+        method: simulationMethod,
         params: [requestParams],
       });
       const prefixedResult = extractGenCallResult(result);
 
+      let decodedResult: `0x${string}` | CalldataEncodable;
       if (args.rawReturn) {
-        return prefixedResult;
+        decodedResult = prefixedResult;
+      } else {
+        const resultBinary = fromHex(prefixedResult, "bytes");
+        decodedResult = calldata.decode(resultBinary) as any;
       }
-      const resultBinary = fromHex(prefixedResult, "bytes");
-      return calldata.decode(resultBinary) as any;
+
+      if (args.includeReceipt) {
+        const feeAccounting = extractGenCallFeeAccounting(result);
+        return {
+          result: decodedResult,
+          receipt: normalizeGenCallReceipt(result, prefixedResult),
+          feeAccounting,
+          feeReport: extractGenCallFeeReport(feeAccounting),
+        } as IncludeReceipt extends true
+          ? SimulateWriteContractResult<RawReturn>
+          : RawReturn extends true ? `0x${string}` : CalldataEncodable;
+      }
+
+      return decodedResult as IncludeReceipt extends true
+        ? SimulateWriteContractResult<RawReturn>
+        : RawReturn extends true ? `0x${string}` : CalldataEncodable;
     },
     /** Executes a state-modifying function on a contract through consensus. Returns the transaction hash. */
     writeContract: async (args: {
@@ -190,9 +351,11 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       functionName: string;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
-      value: bigint;
+      value?: bigint;
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
+      validUntil?: BigNumberish;
+      fees?: TransactionFeeOptions;
     }): Promise<`0x${string}`> => {
       const {
         account,
@@ -203,25 +366,34 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         value = 0n,
         leaderOnly = false,
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
+        validUntil,
+        fees,
       } = args;
 
       const data = [calldata.encode(calldata.makeCalldataObject(functionName, callArgs, kwargs)), leaderOnly];
       const serializedData = serialize(data);
       const senderAccount = account || client.account;
-      const {primaryEncodedData, fallbackEncodedData} = _encodeAddTransactionData({
+      const transactionFees = await _resolveTransactionFees({
+        client,
+        publicClient,
+        fees,
+        numOfInitialValidators: client.chain.defaultNumberOfInitialValidators,
+      });
+      const transactionVariants = _encodeAddTransactionData({
         client,
         senderAccount,
         recipient: address,
         data: serializedData,
         consensusMaxRotations,
+        validUntil,
+        userValue: value,
+        transactionFees,
       });
       return _sendTransaction({
         client,
         publicClient,
-        encodedData: primaryEncodedData,
-        fallbackEncodedData,
+        transactionVariants,
         senderAccount,
-        value,
       });
     },
     /** Deploys a new intelligent contract to GenLayer. Returns the transaction hash. */
@@ -232,6 +404,8 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
+      validUntil?: BigNumberish;
+      fees?: TransactionFeeOptions;
     }) => {
       const {
         account,
@@ -240,6 +414,8 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         kwargs,
         leaderOnly = false,
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
+        validUntil,
+        fees,
       } = args;
 
       const data = [
@@ -249,20 +425,177 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       ];
       const serializedData = serialize(data);
       const senderAccount = account || client.account;
-      const {primaryEncodedData, fallbackEncodedData} = _encodeAddTransactionData({
+      const transactionFees = await _resolveTransactionFees({
+        client,
+        publicClient,
+        fees,
+        numOfInitialValidators: client.chain.defaultNumberOfInitialValidators,
+      });
+      const transactionVariants = _encodeAddTransactionData({
         client,
         senderAccount,
         recipient: zeroAddress,
         data: serializedData,
         consensusMaxRotations,
+        validUntil,
+        userValue: 0n,
+        transactionFees,
       });
       return _sendTransaction({
         client,
         publicClient,
-        encodedData: primaryEncodedData,
-        fallbackEncodedData,
+        transactionVariants,
         senderAccount,
       });
+    },
+    /** Returns the active fee price policy used to build user-side caps. */
+    getCurrentFeePolicy: async (): Promise<FeePolicyQuote> => {
+      return readCurrentFeePolicy(client, publicClient);
+    },
+    /** Builds a fee distribution with caps derived from the active fee policy. */
+    estimateFeesDistribution: async (args?: FeeEstimateOptions): Promise<FeesDistribution> => {
+      const policy = await readCurrentFeePolicy(client, publicClient);
+      return buildEstimatedFeesDistribution(args, policy);
+    },
+    /**
+     * Builds a complete transaction `fees` object, including feeValue.
+     * Studio has no on-chain FeeManager in the chain definition, so this uses
+     * the same deterministic round-fee math as Studio trusted mode there.
+     */
+    estimateTransactionFees: async (args?: FeeEstimateOptions): Promise<TransactionFeeEstimate> => {
+      const policy = await readCurrentFeePolicy(client, publicClient);
+      const distribution = buildEstimatedFeesDistribution(args, policy);
+
+      return {
+        distribution,
+        messageAllocations: args?.messageAllocations,
+        feeValue: await estimateFeeValue(distribution, policy),
+        policy,
+      };
+    },
+    /**
+     * Builds a trusted fee preset from a representative Studio simulation.
+     * This turns the returned fee accounting/report into execution and message
+     * budgets while preserving mode-2 message allocations when the simulation
+     * was run with them.
+     */
+    estimateTransactionFeesFromSimulation: async (
+      args: SimulationFeeEstimateOptions,
+    ): Promise<TransactionFeeEstimate> => {
+      const policy = await readCurrentFeePolicy(client, publicClient);
+      const {estimateOptions, observed, messageAllocations} =
+        buildEstimatedFeesOptionsFromSimulation(args, policy);
+      const distribution = buildEstimatedFeesDistribution(estimateOptions, policy);
+
+      return {
+        distribution,
+        messageAllocations,
+        feeValue: await estimateFeeValue(distribution, policy),
+        policy,
+        observed,
+      };
+    },
+    /**
+     * Builds a trusted fee preset for a concrete write call in one step.
+     * The method first gives the simulation a baseline fee budget, then uses
+     * the returned Studio/GenVM fee accounting to derive the preset the dapp
+     * should pass with the real transaction.
+     */
+    estimateTransactionFeesForWrite: async (
+      args: WriteFeeEstimateOptions,
+    ): Promise<TransactionFeeEstimate> => {
+      const {
+        account,
+        address,
+        functionName,
+        args: callArgs,
+        kwargs,
+        value,
+        leaderOnly = false,
+        transactionHashVariant = TransactionHashVariant.LATEST_NONFINAL,
+        executionHeadroomBps,
+        messageHeadroomBps,
+        ...feeOptions
+      } = args;
+
+      const policy = await readCurrentFeePolicy(client, publicClient);
+      const initialDistribution = buildEstimatedFeesDistribution(feeOptions, policy);
+      const initialEstimate: TransactionFeeEstimate = {
+        distribution: initialDistribution,
+        messageAllocations: feeOptions.messageAllocations,
+        feeValue: await estimateFeeValue(initialDistribution, policy),
+        policy,
+      };
+
+      const encodedData = [
+        calldata.encode(calldata.makeCalldataObject(functionName, callArgs, kwargs)),
+        leaderOnly,
+      ];
+      const serializedData = serialize(encodedData);
+      const senderAddress = account?.address ?? client.account?.address ?? zeroAddress;
+      const requestParams: Record<string, unknown> = {
+        type: "write",
+        to: address,
+        from: senderAddress,
+        data: serializedData,
+        transaction_hash_variant: transactionHashVariant,
+      };
+      const userValue = toUInt(value, "value", 0n);
+      if (userValue > 0n) {
+        requestParams.value = toHex(userValue);
+      }
+      const rpcFees = transactionFeesToRpc({
+        distribution: initialEstimate.distribution,
+        messageAllocations: initialEstimate.messageAllocations,
+        feeValue: initialEstimate.feeValue,
+      });
+      if (rpcFees) {
+        requestParams.fees = rpcFees;
+      }
+
+      if (client.chain.isStudio) {
+        const studioEstimate = await client.request({
+          method: "sim_estimateTransactionFees",
+          params: [requestParams],
+        });
+        const authoritativeEstimate = transactionFeeEstimateFromStudioEstimate(
+          studioEstimate,
+          policy,
+        );
+        if (authoritativeEstimate) {
+          return authoritativeEstimate;
+        }
+      }
+
+      const simulationResult = await client.request({
+        method: "gen_call",
+        params: [requestParams],
+      });
+      extractGenCallResult(simulationResult);
+      const feeAccounting = extractGenCallFeeAccounting(simulationResult);
+      const simulation = {
+        feeAccounting,
+        feeReport: extractGenCallFeeReport(feeAccounting),
+      };
+      const {estimateOptions, observed, messageAllocations} =
+        buildEstimatedFeesOptionsFromSimulation(
+          {
+            ...feeOptions,
+            executionHeadroomBps,
+            messageHeadroomBps,
+            simulation,
+          },
+          policy,
+        );
+      const distribution = buildEstimatedFeesDistribution(estimateOptions, policy);
+
+      return {
+        distribution,
+        messageAllocations,
+        feeValue: await estimateFeeValue(distribution, policy),
+        policy,
+        observed,
+      };
     },
     /** Calculates the minimum bond required to appeal a transaction. */
     getMinAppealBond: async (args: {txId: `0x${string}`}): Promise<bigint> => {
@@ -346,30 +679,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       value?: bigint;
     }) => {
       const {account, txId} = args;
-      let {value} = args;
-
-      if (value === undefined) {
-        if (client.chain.feeManagerContract?.address && client.chain.roundsStorageContract?.address) {
-          const roundNumber = await publicClient.readContract({
-            address: client.chain.roundsStorageContract.address as `0x${string}`,
-            abi: client.chain.roundsStorageContract.abi as Abi,
-            functionName: "getRoundNumber",
-            args: [txId],
-          }) as bigint;
-
-          const transaction = await client.getTransaction({hash: txId as TransactionHash});
-          const txStatus = Number(transaction.status);
-
-          value = await publicClient.readContract({
-            address: client.chain.feeManagerContract.address as `0x${string}`,
-            abi: client.chain.feeManagerContract.abi as Abi,
-            functionName: "calculateMinAppealBond",
-            args: [txId, roundNumber, txStatus],
-          }) as bigint;
-        } else {
-          value = 0n;
-        }
-      }
+      const value = await _resolveAppealValue({client, publicClient, txId, value: args.value});
 
       const senderAccount = account || client.account;
       const encodedData = _encodeSubmitAppealData({client, txId});
@@ -383,6 +693,54 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         senderAccount,
         value,
         operationName: "Appeal",
+      });
+      return txId;
+    },
+    /**
+     * Deposits additional fee budget for an existing consensus transaction.
+     * Returns the backend RPC hash: an EVM transaction hash on network
+     * backends, or the target GenLayer tx id on Studio/localnet.
+     */
+    topUpFees: async (args: {
+      account?: Account;
+      txId: `0x${string}`;
+      distribution: FeesDistributionInput;
+      value: bigint;
+    }): Promise<`0x${string}`> => {
+      const {account, txId, distribution, value} = args;
+      const senderAccount = account || client.account;
+      const encodedData = _encodeTopUpFeesData({txId, distribution});
+      return _sendConsensusCall({
+        client,
+        publicClient,
+        encodedData,
+        senderAccount,
+        value,
+        operationName: "Top up fees",
+      });
+    },
+    /**
+     * Deposits appeal fee budget and submits an appeal in the same consensus call.
+     * Returns the existing GenLayer transaction id, matching appealTransaction.
+     */
+    topUpAndSubmitAppeal: async (args: {
+      account?: Account;
+      txId: `0x${string}`;
+      distribution: FeesDistributionInput;
+      value?: bigint;
+    }): Promise<`0x${string}`> => {
+      const {account, txId, distribution} = args;
+      const value = await _resolveAppealValue({client, publicClient, txId, value: args.value});
+
+      const senderAccount = account || client.account;
+      const encodedData = _encodeTopUpAndSubmitAppealData({txId, distribution});
+      await _sendConsensusCall({
+        client,
+        publicClient,
+        encodedData,
+        senderAccount,
+        value,
+        operationName: "Top up and submit appeal",
       });
       return txId;
     },
@@ -473,7 +831,7 @@ const ADD_TRANSACTION_ABI_V6 = [
   {
     type: "function",
     name: "addTransaction",
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     inputs: [
       {name: "_sender", type: "address"},
       {name: "_recipient", type: "address"},
@@ -486,9 +844,124 @@ const ADD_TRANSACTION_ABI_V6 = [
   },
 ] as const;
 
-const getAddTransactionInputCount = (abi: readonly unknown[] | undefined): number => {
+const FEES_DISTRIBUTION_COMPONENTS = [
+  {name: "leaderTimeunitsAllocation", type: "uint256"},
+  {name: "validatorTimeunitsAllocation", type: "uint256"},
+  {name: "appealRounds", type: "uint256"},
+  {name: "executionBudgetPerRound", type: "uint256"},
+  {name: "executionConsumed", type: "uint256"},
+  {name: "totalMessageFees", type: "uint256"},
+  {name: "rotations", type: "uint256[]"},
+  {name: "maxPriceGenPerTimeUnit", type: "uint256"},
+  {name: "storageFeeMaxGasPrice", type: "uint256"},
+  {name: "receiptFeeMaxGasPrice", type: "uint256"},
+] as const;
+
+const MESSAGE_FEE_ALLOCATION_COMPONENTS = [
+  {name: "messageType", type: "uint8"},
+  {name: "onAcceptance", type: "bool"},
+  {name: "parentIndex", type: "uint256"},
+  {name: "recipient", type: "address"},
+  {name: "callKey", type: "bytes32"},
+  {name: "budget", type: "uint256"},
+  {name: "feeParams", type: "bytes"},
+] as const;
+
+const ADD_TRANSACTION_PARAMS_COMPONENTS = [
+  {name: "sender", type: "address"},
+  {name: "recipient", type: "address"},
+  {name: "numOfInitialValidators", type: "uint256"},
+  {name: "maxRotations", type: "uint256"},
+  {name: "validUntil", type: "uint256"},
+  {name: "saltNonce", type: "uint256"},
+  {name: "userValue", type: "uint256"},
+  {name: "feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+  {name: "txCalldata", type: "bytes"},
+  {name: "messageAllocations", type: "tuple[]", components: MESSAGE_FEE_ALLOCATION_COMPONENTS},
+] as const;
+
+const ADD_TRANSACTION_ABI_WITH_FEES = [
+  {
+    type: "function",
+    name: "addTransaction",
+    stateMutability: "payable",
+    inputs: [
+      {name: "_params", type: "tuple", components: ADD_TRANSACTION_PARAMS_COMPONENTS},
+    ],
+    outputs: [],
+  },
+] as const;
+
+const CONSENSUS_FEE_MANAGEMENT_ABI = [
+  {
+    type: "function",
+    name: "topUpFees",
+    stateMutability: "payable",
+    inputs: [
+      {name: "_txId", type: "bytes32"},
+      {name: "_feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "topUpAndSubmitAppeal",
+    stateMutability: "payable",
+    inputs: [
+      {name: "_txId", type: "bytes32"},
+      {name: "_feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+    ],
+    outputs: [],
+  },
+] as const;
+
+const FEE_MANAGER_CALCULATE_ROUND_FEES_ABI = [
+  {
+    type: "function",
+    name: "GENPerTimeUnit",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "storageUnitPrice",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "quoteGasPrice",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "messageFeeParamsBudgetFloor",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "uint256"}],
+  },
+  {
+    type: "function",
+    name: "calculateRoundFees",
+    stateMutability: "view",
+    inputs: [
+      {name: "_feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+      {name: "_numOfValidators", type: "uint256"},
+      {name: "round", type: "uint256"},
+    ],
+    outputs: [{name: "totalFeesToPay", type: "uint256"}],
+  },
+] as const;
+
+type AddTransactionAbiVersion = "fees" | "v6" | "v5";
+
+const getAddTransactionAbiVersion = (abi: readonly unknown[] | undefined): AddTransactionAbiVersion => {
   if (!abi || !Array.isArray(abi)) {
-    return 0;
+    return "v5";
   }
 
   const addTransactionFunction = abi.find(item => {
@@ -498,9 +971,631 @@ const getAddTransactionInputCount = (abi: readonly unknown[] | undefined): numbe
 
     const candidate = item as {type?: string; name?: string};
     return candidate.type === "function" && candidate.name === "addTransaction";
-  }) as {inputs?: readonly unknown[]} | undefined;
+  }) as {inputs?: readonly {type?: string; components?: readonly unknown[]}[]} | undefined;
 
-  return Array.isArray(addTransactionFunction?.inputs) ? addTransactionFunction.inputs.length : 0;
+  const inputs = addTransactionFunction?.inputs;
+  if (!Array.isArray(inputs)) {
+    return "v5";
+  }
+
+  if (inputs.length === 1 && inputs[0]?.type === "tuple") {
+    return "fees";
+  }
+
+  return inputs.length >= 6 ? "v6" : "v5";
+};
+
+type EncodedTransactionVariant = {
+  encodedData: `0x${string}`;
+  value: bigint;
+};
+
+const toUInt = (value: BigNumberish | undefined, fieldName: string, fallback: bigint): bigint => {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error(`${fieldName} must be a safe integer when provided as a number.`);
+  }
+  const normalized = BigInt(value);
+  if (normalized < 0n) {
+    throw new Error(`${fieldName} must be greater than or equal to zero.`);
+  }
+  return normalized;
+};
+
+const getDefaultValidUntil = () => BigInt(Math.floor(Date.now() / 1000) + 3600);
+
+const requiresFeeDepositCalculation = (distribution: FeesDistribution): boolean => (
+  distribution.leaderTimeunitsAllocation !== 0n ||
+  distribution.validatorTimeunitsAllocation !== 0n ||
+  distribution.executionBudgetPerRound !== 0n ||
+  distribution.totalMessageFees !== 0n
+);
+
+const DEFAULT_PRICE_CAP_HEADROOM_BPS = 12_000n;
+const DEFAULT_LEADER_TIMEUNITS_ALLOCATION = 100n;
+const DEFAULT_VALIDATOR_TIMEUNITS_ALLOCATION = 200n;
+const DEFAULT_TRANSACTION_EXECUTION_BUDGET_PER_ROUND = 500_000n;
+const MIN_RECEIPT_BYTES = 512n;
+const DEFAULT_RECEIPT_SLOTS_CHANGED = 7n;
+const DEFAULT_INTRINSIC_GAS = 21_000n;
+const DEFAULT_BOOTLOADER_OVERHEAD = 60_000n;
+const DEFAULT_GAS_PER_CHANGED_SLOT = 1_000n;
+const DEFAULT_CALLDATA_GAS_PER_BYTE = 16n;
+const DEFAULT_FIXED_PROPOSE_RECEIPT_GAS = 210_000n;
+const TRANSACTION_GAS_HEADROOM_BPS = 20_000n;
+const VALIDATORS_PER_ROUND = [
+  5n,
+  7n,
+  11n,
+  13n,
+  23n,
+  25n,
+  47n,
+  49n,
+  95n,
+  97n,
+  191n,
+  193n,
+  383n,
+  385n,
+  767n,
+  769n,
+  1535n,
+  1537n,
+] as const;
+
+const withCapHeadroom = (value: bigint, headroomBps: bigint): bigint => {
+  if (value === 0n) return 0n;
+  return (value * headroomBps + 9_999n) / 10_000n;
+};
+
+const withTransactionGasHeadroom = (value: bigint): bigint => {
+  if (value === 0n) return 0n;
+  return (value * TRANSACTION_GAS_HEADROOM_BPS + 9_999n) / 10_000n;
+};
+
+const bigintFromUnknown = (value: unknown, fieldName: string, fallback = 0n): bigint => {
+  if (value == null) return fallback;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isSafeInteger(value)) return BigInt(value);
+  if (typeof value === "string" && value.trim() !== "") return BigInt(value);
+  throw new Error(`${fieldName} is not an integer value.`);
+};
+
+const extractStudioFeePolicy = (config: unknown): FeePolicyQuote => {
+  const configRecord = config && typeof config === "object" && !Array.isArray(config)
+    ? config as Record<string, unknown>
+    : undefined;
+  const policy = configRecord?.policy;
+  const enabled = configRecord?.enabled;
+  if (enabled !== undefined && typeof enabled !== "boolean") {
+    throw new Error(`sim_getFeeConfig enabled flag is not a boolean.`);
+  }
+
+  const policyRecord = policy && typeof policy === "object" && !Array.isArray(policy)
+    ? policy as Record<string, unknown>
+    : undefined;
+  if (!policyRecord) {
+    throw new Error(`sim_getFeeConfig did not expose a policy object.`);
+  }
+  const genPerTimeUnit = bigintFromUnknown(policyRecord.genPerTimeUnit, "policy.genPerTimeUnit");
+  const storageUnitPrice = bigintFromUnknown(policyRecord.storageUnitPrice, "policy.storageUnitPrice");
+  const receiptGasPrice = bigintFromUnknown(policyRecord.receiptGasPrice, "policy.receiptGasPrice");
+  const intrinsicGas = bigintFromUnknown(policyRecord.intrinsicGas, "policy.intrinsicGas", DEFAULT_INTRINSIC_GAS);
+  const bootloaderOverhead = bigintFromUnknown(
+    policyRecord.bootloaderOverhead,
+    "policy.bootloaderOverhead",
+    DEFAULT_BOOTLOADER_OVERHEAD,
+  );
+  const gasPerChangedSlot = bigintFromUnknown(
+    policyRecord.gasPerChangedSlot,
+    "policy.gasPerChangedSlot",
+    DEFAULT_GAS_PER_CHANGED_SLOT,
+  );
+  const calldataGasPerByte = bigintFromUnknown(
+    policyRecord.calldataGasPerByte,
+    "policy.calldataGasPerByte",
+    DEFAULT_CALLDATA_GAS_PER_BYTE,
+  );
+  const fixedProposeReceiptGas = bigintFromUnknown(
+    policyRecord.fixedProposeReceiptGas,
+    "policy.fixedProposeReceiptGas",
+    DEFAULT_FIXED_PROPOSE_RECEIPT_GAS,
+  );
+  const executionBudgetFloor = policyRecord.messageFeeParamsBudgetFloor == null
+    ? receiptGasPrice * (
+        fixedProposeReceiptGas +
+        intrinsicGas +
+        bootloaderOverhead +
+        (MIN_RECEIPT_BYTES * calldataGasPerByte) +
+        (DEFAULT_RECEIPT_SLOTS_CHANGED * gasPerChangedSlot)
+      )
+    : bigintFromUnknown(
+        policyRecord.messageFeeParamsBudgetFloor,
+        "policy.messageFeeParamsBudgetFloor",
+      );
+
+  return {
+    enabled: enabled ?? (
+      genPerTimeUnit > 0n ||
+      storageUnitPrice > 0n ||
+      receiptGasPrice > 0n
+    ),
+    genPerTimeUnit,
+    storageUnitPrice,
+    receiptGasPrice,
+    executionBudgetFloor,
+  };
+};
+
+const readCurrentFeePolicy = async (
+  client: GenLayerClient<GenLayerChain>,
+  publicClient: PublicClient,
+): Promise<FeePolicyQuote> => {
+  if (client.chain.isStudio) {
+    const config = await client.request({method: "sim_getFeeConfig", params: []});
+    return extractStudioFeePolicy(config);
+  }
+
+  if (!client.chain.feeManagerContract?.address) {
+    throw new Error("Fee policy estimation is not supported on this chain (missing feeManagerContract).");
+  }
+
+  const address = client.chain.feeManagerContract.address as `0x${string}`;
+  const abi = FEE_MANAGER_CALCULATE_ROUND_FEES_ABI as any;
+  const [genPerTimeUnit, storageUnitPrice, receiptGasPrice, executionBudgetFloor] = await Promise.all([
+    publicClient.readContract({address, abi, functionName: "GENPerTimeUnit", args: []}) as Promise<bigint>,
+    publicClient.readContract({address, abi, functionName: "storageUnitPrice", args: []}) as Promise<bigint>,
+    publicClient.readContract({address, abi, functionName: "quoteGasPrice", args: []}) as Promise<bigint>,
+    publicClient.readContract({address, abi, functionName: "messageFeeParamsBudgetFloor", args: []}) as Promise<bigint>,
+  ]);
+
+  return {
+    enabled: genPerTimeUnit > 0n || storageUnitPrice > 0n || receiptGasPrice > 0n,
+    genPerTimeUnit,
+    storageUnitPrice,
+    receiptGasPrice,
+    executionBudgetFloor,
+  };
+};
+
+const maxBigint = (...values: bigint[]): bigint => values.reduce(
+  (max, value) => value > max ? value : max,
+  0n,
+);
+
+const defaultExecutionBudgetPerRound = (policy: FeePolicyQuote): bigint => {
+  if (!policy.enabled || (policy.storageUnitPrice === 0n && policy.receiptGasPrice === 0n)) {
+    return 0n;
+  }
+
+  return maxBigint(
+    DEFAULT_TRANSACTION_EXECUTION_BUDGET_PER_ROUND,
+    policy.executionBudgetFloor,
+  );
+};
+
+const buildEstimatedFeesDistribution = (
+  options: FeeEstimateOptions | undefined,
+  policy: FeePolicyQuote,
+): FeesDistribution => {
+  const headroomBps = toUInt(
+    options?.priceCapHeadroomBps,
+    "priceCapHeadroomBps",
+    DEFAULT_PRICE_CAP_HEADROOM_BPS,
+  );
+  const executionBudgetDefault = defaultExecutionBudgetPerRound(policy);
+  const totalMessageFees = options?.totalMessageFees ?? (
+    options?.messageAllocations
+      ? normalizeMessageFeeAllocations(options.messageAllocations).reduce(
+          (sum, allocation) => {
+            if (
+              allocation.messageType === MessageType.External ||
+              allocation.parentIndex === MESSAGE_ALLOCATION_ROOT_PARENT_INDEX
+            ) {
+              return sum + allocation.budget;
+            }
+            return sum;
+          },
+          0n,
+        )
+      : undefined
+  );
+
+  return createFeesDistribution({
+    leaderTimeunitsAllocation: options?.leaderTimeunitsAllocation ?? (
+      policy.enabled ? DEFAULT_LEADER_TIMEUNITS_ALLOCATION : 0n
+    ),
+    validatorTimeunitsAllocation: options?.validatorTimeunitsAllocation ?? (
+      policy.enabled ? DEFAULT_VALIDATOR_TIMEUNITS_ALLOCATION : 0n
+    ),
+    appealRounds: options?.appealRounds,
+    executionBudgetPerRound: options?.executionBudgetPerRound ?? executionBudgetDefault,
+    executionConsumed: options?.executionConsumed,
+    totalMessageFees,
+    rotations: options?.rotations,
+    maxPriceGenPerTimeUnit:
+      options?.maxPriceGenPerTimeUnit ?? withCapHeadroom(policy.genPerTimeUnit, headroomBps),
+    storageFeeMaxGasPrice:
+      options?.storageFeeMaxGasPrice ?? withCapHeadroom(policy.storageUnitPrice, headroomBps),
+    receiptFeeMaxGasPrice:
+      options?.receiptFeeMaxGasPrice ?? withCapHeadroom(policy.receiptGasPrice, headroomBps),
+  });
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined => (
+  value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+);
+
+const feeAccountingFromSimulation = (
+  simulation: SimulationFeeEstimateOptions["simulation"],
+): StudioFeeAccounting | undefined => {
+  const direct = simulation.feeAccounting;
+  if (direct) return direct;
+
+  const receipt = asRecord((simulation as {receipt?: unknown}).receipt);
+  const genvmResult = asRecord(receipt?.genvm_result);
+  const feeAccounting = asRecord(genvmResult?.fee_accounting);
+  return feeAccounting as StudioFeeAccounting | undefined;
+};
+
+const messageAllocationsFromAccounting = (
+  accounting: StudioFeeAccounting | undefined,
+): MessageFeeAllocationInput[] | undefined => {
+  if (!Array.isArray(accounting?.message_allocations) || accounting.message_allocations.length === 0) {
+    return undefined;
+  }
+
+  return accounting.message_allocations.map((raw, index) => {
+    const allocation = asRecord(raw);
+    if (!allocation) {
+      throw new Error(`simulation.feeAccounting.message_allocations[${index}] must be an object.`);
+    }
+    return {
+      messageType: Number(toUInt(
+        allocation.messageType as BigNumberish | undefined,
+        `simulation.feeAccounting.message_allocations[${index}].messageType`,
+        0n,
+      )) as MessageType,
+      onAcceptance: Boolean(allocation.onAcceptance),
+      parentIndex: toUInt(
+        allocation.parentIndex as BigNumberish | undefined,
+        `simulation.feeAccounting.message_allocations[${index}].parentIndex`,
+        MESSAGE_ALLOCATION_ROOT_PARENT_INDEX,
+      ),
+      recipient: String(allocation.recipient ?? zeroAddress) as Address,
+      callKey: prefixHex(String(allocation.callKey ?? CALL_KEY_WILDCARD)) as `0x${string}`,
+      budget: toUInt(
+        allocation.budget as BigNumberish | undefined,
+        `simulation.feeAccounting.message_allocations[${index}].budget`,
+        0n,
+      ),
+      feeParams: prefixHex(String(allocation.feeParams ?? "0x")) as `0x${string}`,
+    };
+  });
+};
+
+const observedSimulationFeeUsage = (
+  args: SimulationFeeEstimateOptions,
+  policy: FeePolicyQuote,
+): SimulationFeeUsage => {
+  const accounting = feeAccountingFromSimulation(args.simulation);
+  const report = args.simulation.feeReport ?? accounting?.execution_fee_report;
+  const executionHeadroomBps = toUInt(
+    args.executionHeadroomBps,
+    "executionHeadroomBps",
+    DEFAULT_PRICE_CAP_HEADROOM_BPS,
+  );
+  const messageHeadroomBps = toUInt(
+    args.messageHeadroomBps,
+    "messageHeadroomBps",
+    DEFAULT_PRICE_CAP_HEADROOM_BPS,
+  );
+
+  const executionFeeConsumed = bigintFromUnknown(
+    accounting?.execution_fee_consumed,
+    "simulation.feeAccounting.execution_fee_consumed",
+  );
+  const executionFeeReportTotal = bigintFromUnknown(
+    report?.totalEstimatedFee,
+    "simulation.feeReport.totalEstimatedFee",
+  );
+  const observedExecutionBudget = executionFeeConsumed + executionFeeReportTotal;
+  const recommendedExecutionBudgetPerRound = observedExecutionBudget > 0n
+    ? maxBigint(
+        defaultExecutionBudgetPerRound(policy),
+        withCapHeadroom(observedExecutionBudget, executionHeadroomBps),
+      )
+    : 0n;
+
+  const messageFeeConsumed = bigintFromUnknown(
+    accounting?.message_fee_consumed,
+    "simulation.feeAccounting.message_fee_consumed",
+  );
+  const genvmMessageFeeConsumed = bigintFromUnknown(
+    accounting?.genvm_message_fee_consumed,
+    "simulation.feeAccounting.genvm_message_fee_consumed",
+  );
+  const messageFeeBudget = bigintFromUnknown(
+    accounting?.message_fee_budget,
+    "simulation.feeAccounting.message_fee_budget",
+  );
+  const externalMessageReimbursed = bigintFromUnknown(
+    accounting?.external_message_fee_reimbursed,
+    "simulation.feeAccounting.external_message_fee_reimbursed",
+  );
+  const messageFeeRefunded = bigintFromUnknown(
+    accounting?.message_fee_refunded,
+    "simulation.feeAccounting.message_fee_refunded",
+  );
+  const externalMessageReserved = bigintFromUnknown(
+    accounting?.external_message_fee_reserved,
+    "simulation.feeAccounting.external_message_fee_reserved",
+  );
+  const externalMessageRemainder = bigintFromUnknown(
+    accounting?.external_message_fee_remainder,
+    "simulation.feeAccounting.external_message_fee_remainder",
+  );
+  const internalDeclaredBudget = (report?.messageReveal?.messages ?? []).reduce(
+    (sum, message, index) => (
+      message.messageType === "Internal"
+        ? sum + bigintFromUnknown(
+            message.declaredBudget,
+            `simulation.feeReport.messageReveal.messages[${index}].declaredBudget`,
+          )
+        : sum
+    ),
+    0n,
+  );
+  const observedMessageBudget = maxBigint(
+    messageFeeConsumed,
+    internalDeclaredBudget + externalMessageReimbursed,
+  );
+
+  return {
+    executionFeeConsumed,
+    executionFeeReportTotal,
+    recommendedExecutionBudgetPerRound,
+    genvmMessageFeeConsumed,
+    messageFeeBudget,
+    messageFeeConsumed,
+    messageFeeRefunded,
+    internalDeclaredBudget,
+    externalMessageReserved,
+    externalMessageReimbursed,
+    externalMessageRemainder,
+    recommendedTotalMessageFees: observedMessageBudget > 0n
+      ? withCapHeadroom(observedMessageBudget, messageHeadroomBps)
+      : 0n,
+  };
+};
+
+const transactionFeeEstimateFromStudioEstimate = (
+  result: unknown,
+  policy: FeePolicyQuote,
+): TransactionFeeEstimate | undefined => {
+  const estimate = asRecord(result);
+  const preset = asRecord(estimate?.recommendedPreset);
+  const distributionInput = asRecord(preset?.distribution);
+  if (!preset || !distributionInput || preset.feeValue === undefined) {
+    return undefined;
+  }
+
+  const rawAllocations = Array.isArray(preset.messageAllocations)
+    ? preset.messageAllocations as MessageFeeAllocationInput[]
+    : undefined;
+  const feeAccounting = asRecord(estimate?.feeAccounting) as StudioFeeAccounting | undefined;
+  const feeReport = (
+    asRecord(estimate?.feeReport) ??
+    asRecord(feeAccounting?.execution_fee_report)
+  ) as StudioExecutionFeeReport | undefined;
+
+  return {
+    distribution: createFeesDistribution(distributionInput as FeesDistributionInput),
+    messageAllocations: rawAllocations && rawAllocations.length > 0
+      ? normalizeMessageFeeAllocations(rawAllocations)
+      : undefined,
+    feeValue: bigintFromUnknown(preset.feeValue, "recommendedPreset.feeValue"),
+    policy,
+    observed: observedSimulationFeeUsage(
+      {
+        simulation: {
+          feeAccounting,
+          feeReport,
+        },
+      },
+      policy,
+    ),
+  };
+};
+
+const buildEstimatedFeesOptionsFromSimulation = (
+  args: SimulationFeeEstimateOptions,
+  policy: FeePolicyQuote,
+): {
+  estimateOptions: FeeEstimateOptions;
+  observed: SimulationFeeUsage;
+  messageAllocations?: MessageFeeAllocationInput[];
+} => {
+  const {
+    simulation,
+    executionHeadroomBps,
+    messageHeadroomBps,
+    ...feeOptions
+  } = args;
+  void simulation;
+  void executionHeadroomBps;
+  void messageHeadroomBps;
+
+  const accounting = feeAccountingFromSimulation(args.simulation);
+  const observed = observedSimulationFeeUsage(args, policy);
+  const messageAllocations =
+    feeOptions.messageAllocations ?? messageAllocationsFromAccounting(accounting);
+
+  return {
+    estimateOptions: {
+      ...feeOptions,
+      messageAllocations,
+      executionBudgetPerRound: feeOptions.executionBudgetPerRound ?? (
+        observed.recommendedExecutionBudgetPerRound > 0n
+          ? observed.recommendedExecutionBudgetPerRound
+          : undefined
+      ),
+      totalMessageFees: feeOptions.totalMessageFees ?? (
+        messageAllocations
+          ? undefined
+          : observed.recommendedTotalMessageFees > 0n
+            ? observed.recommendedTotalMessageFees
+            : undefined
+      ),
+    },
+    observed,
+    messageAllocations,
+  };
+};
+
+const validatorIndex = (numOfValidators: number): number => {
+  const needle = BigInt(numOfValidators);
+  const index = VALIDATORS_PER_ROUND.findIndex((validators) => validators === needle);
+  if (index < 0) {
+    throw new Error(`InvalidNumOfValidators: ${numOfValidators}`);
+  }
+  return index;
+};
+
+const calculateFeeForRound = (
+  numOfValidators: bigint,
+  rotations: bigint,
+  leaderTimeunitsAllocation: bigint,
+  validatorTimeunitsAllocation: bigint,
+): bigint => rotations * (
+  leaderTimeunitsAllocation + (numOfValidators * validatorTimeunitsAllocation)
+);
+
+const calculateLocalRoundFees = (
+  distribution: FeesDistribution,
+  numOfInitialValidators: number,
+  policy: FeePolicyQuote,
+): bigint => {
+  if (distribution.appealRounds !== BigInt(distribution.rotations.length - 1)) {
+    throw new Error("InvalidAppealRounds");
+  }
+  if (
+    distribution.maxPriceGenPerTimeUnit > 0n &&
+    policy.genPerTimeUnit > distribution.maxPriceGenPerTimeUnit
+  ) {
+    throw new Error("MaxPriceExceeded");
+  }
+  if (
+    distribution.storageFeeMaxGasPrice > 0n &&
+    policy.storageUnitPrice > distribution.storageFeeMaxGasPrice
+  ) {
+    throw new Error("MaxPriceExceeded");
+  }
+  if (
+    distribution.receiptFeeMaxGasPrice > 0n &&
+    policy.receiptGasPrice > distribution.receiptFeeMaxGasPrice
+  ) {
+    throw new Error("MaxPriceExceeded");
+  }
+
+  const startIndex = validatorIndex(numOfInitialValidators);
+  if (startIndex + Number(distribution.appealRounds * 2n) >= VALIDATORS_PER_ROUND.length) {
+    throw new Error("InvalidNumOfValidators");
+  }
+
+  let total = calculateFeeForRound(
+    VALIDATORS_PER_ROUND[startIndex],
+    distribution.rotations[0] + 1n,
+    distribution.leaderTimeunitsAllocation,
+    distribution.validatorTimeunitsAllocation,
+  );
+  let rotationsIndex = 1;
+  let rotationsThisRound = 1n;
+  for (let offset = 1; offset <= Number(distribution.appealRounds * 2n); offset++) {
+    if (offset % 2 === 0 && rotationsIndex < distribution.rotations.length) {
+      rotationsThisRound = distribution.rotations[rotationsIndex] + 1n;
+      rotationsIndex += 1;
+    } else if (offset % 2 === 1) {
+      rotationsThisRound = 1n;
+    }
+
+    total += calculateFeeForRound(
+      VALIDATORS_PER_ROUND[startIndex + offset],
+      rotationsThisRound,
+      distribution.leaderTimeunitsAllocation,
+      distribution.validatorTimeunitsAllocation,
+    );
+  }
+
+  if (policy.genPerTimeUnit > 0n) {
+    total *= policy.genPerTimeUnit;
+  }
+
+  const leaderRounds = distribution.rotations.reduce(
+    (sum, rotations) => sum + rotations + 1n,
+    distribution.appealRounds,
+  );
+  total += distribution.executionBudgetPerRound * leaderRounds;
+  return total;
+};
+
+const _resolveTransactionFees = async ({
+  client,
+  publicClient,
+  fees,
+  numOfInitialValidators,
+}: {
+  client: GenLayerClient<GenLayerChain>;
+  publicClient: PublicClient;
+  fees?: TransactionFeeOptions;
+  numOfInitialValidators: number;
+}): Promise<NormalizedTransactionFees> => {
+  const transactionFees = normalizeTransactionFees(fees);
+  if (transactionFees.feeValue !== undefined || !requiresFeeDepositCalculation(transactionFees.distribution)) {
+    return {
+      ...transactionFees,
+      feeValue: transactionFees.feeValue ?? 0n,
+    };
+  }
+
+  if (!client.chain.feeManagerContract?.address) {
+    if (client.chain.isStudio) {
+      const policy = await readCurrentFeePolicy(client, publicClient);
+      return {
+        ...transactionFees,
+        feeValue: policy.enabled
+          ? calculateLocalRoundFees(
+              transactionFees.distribution,
+              numOfInitialValidators,
+              policy,
+            ) + transactionFees.distribution.totalMessageFees
+          : 0n,
+      };
+    }
+
+    throw new Error("fees.feeValue is required when the chain does not expose a feeManagerContract.");
+  }
+
+  const roundFees = await publicClient.readContract({
+    address: client.chain.feeManagerContract.address as `0x${string}`,
+    abi: FEE_MANAGER_CALCULATE_ROUND_FEES_ABI as any,
+    functionName: "calculateRoundFees",
+    args: [
+      transactionFees.distribution,
+      BigInt(numOfInitialValidators),
+      0n,
+    ],
+  }) as bigint;
+
+  return {
+    ...transactionFees,
+    feeValue: roundFees + transactionFees.distribution.totalMessageFees,
+  };
 };
 
 const _encodeAddTransactionData = ({
@@ -509,58 +1604,97 @@ const _encodeAddTransactionData = ({
   recipient,
   data,
   consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
+  validUntil,
+  userValue = 0n,
+  transactionFees,
 }: {
   client: GenLayerClient<GenLayerChain>;
   senderAccount?: Account;
   recipient?: `0x${string}`;
   data?: `0x${string}`;
   consensusMaxRotations?: number;
-}): {primaryEncodedData: `0x${string}`; fallbackEncodedData: `0x${string}`} => {
+  validUntil?: BigNumberish;
+  userValue?: bigint;
+  transactionFees: NormalizedTransactionFees;
+}): EncodedTransactionVariant[] => {
   const validatedSenderAccount = validateAccount(senderAccount);
+  const txCalldata = data ?? "0x";
+  const txRecipient = recipient ?? zeroAddress;
+  const txValidUntil = toUInt(validUntil, "validUntil", getDefaultValidUntil());
+  const feeValue = transactionFees.feeValue ?? 0n;
 
   const addTransactionArgs: [
     Address,
-    `0x${string}` | undefined,
+    `0x${string}`,
     number,
-    number | undefined,
-    `0x${string}` | undefined,
+    number,
+    `0x${string}`,
   ] = [
     validatedSenderAccount.address,
-    recipient,
+    txRecipient,
     client.chain.defaultNumberOfInitialValidators,
     consensusMaxRotations,
-    data,
+    txCalldata,
   ];
 
-  const encodedDataV5 = encodeFunctionData({
-    abi: ADD_TRANSACTION_ABI_V5 as any,
-    functionName: "addTransaction",
-    args: addTransactionArgs,
-  });
+  const buildVariant = (abiVersion: AddTransactionAbiVersion): EncodedTransactionVariant => {
+    if (abiVersion === "fees") {
+      const params = {
+        sender: validatedSenderAccount.address,
+        recipient: txRecipient,
+        numOfInitialValidators: BigInt(client.chain.defaultNumberOfInitialValidators),
+        maxRotations: BigInt(consensusMaxRotations),
+        validUntil: txValidUntil,
+        saltNonce: 0n,
+        userValue,
+        feesDistribution: transactionFees.distribution,
+        txCalldata,
+        messageAllocations: transactionFees.messageAllocations,
+      };
 
-  // `_validUntil = 0` is treated as "expired" by the on-chain consensus
-  // contract, so every submission with a v6 signature would revert. Use
-  // `now + 1 hour` — enough buffer for wallet confirmation + mining, short
-  // enough that stale signed txs don't hang around forever.
-  const validUntil = BigInt(Math.floor(Date.now() / 1000) + 3600);
+      return {
+        encodedData: encodeFunctionData({
+          abi: ADD_TRANSACTION_ABI_WITH_FEES as any,
+          functionName: "addTransaction",
+          args: [params],
+        }),
+        value: userValue + feeValue,
+      };
+    }
 
-  const encodedDataV6 = encodeFunctionData({
-    abi: ADD_TRANSACTION_ABI_V6 as any,
-    functionName: "addTransaction",
-    args: [...addTransactionArgs, validUntil],
-  });
+    if (abiVersion === "v6") {
+      return {
+        encodedData: encodeFunctionData({
+          abi: ADD_TRANSACTION_ABI_V6 as any,
+          functionName: "addTransaction",
+          args: [...addTransactionArgs, txValidUntil],
+        }),
+        value: userValue,
+      };
+    }
 
-  if (getAddTransactionInputCount(client.chain.consensusMainContract?.abi) >= 6) {
     return {
-      primaryEncodedData: encodedDataV6,
-      fallbackEncodedData: encodedDataV5,
+      encodedData: encodeFunctionData({
+        abi: ADD_TRANSACTION_ABI_V5 as any,
+        functionName: "addTransaction",
+        args: addTransactionArgs,
+      }),
+      value: userValue,
     };
+  };
+
+  if (transactionFees.requiresFeeAwareTransaction) {
+    return [buildVariant("fees")];
   }
 
-  return {
-    primaryEncodedData: encodedDataV5,
-    fallbackEncodedData: encodedDataV6,
+  const detectedVersion = getAddTransactionAbiVersion(client.chain.consensusMainContract?.abi);
+  const orderByDetectedVersion: Record<AddTransactionAbiVersion, AddTransactionAbiVersion[]> = {
+    fees: ["fees", "v6", "v5"],
+    v6: ["v6", "v5", "fees"],
+    v5: ["v5", "v6", "fees"],
   };
+
+  return orderByDetectedVersion[detectedVersion].map(buildVariant);
 };
 
 const _encodeSubmitAppealData = ({
@@ -577,12 +1711,78 @@ const _encodeSubmitAppealData = ({
   });
 };
 
+const _resolveAppealValue = async ({
+  client,
+  publicClient,
+  txId,
+  value,
+}: {
+  client: GenLayerClient<GenLayerChain>;
+  publicClient: PublicClient;
+  txId: `0x${string}`;
+  value?: bigint;
+}): Promise<bigint> => {
+  if (value !== undefined) {
+    return value;
+  }
+
+  if (!client.chain.feeManagerContract?.address || !client.chain.roundsStorageContract?.address) {
+    return 0n;
+  }
+
+  const roundNumber = await publicClient.readContract({
+    address: client.chain.roundsStorageContract.address as `0x${string}`,
+    abi: client.chain.roundsStorageContract.abi as Abi,
+    functionName: "getRoundNumber",
+    args: [txId],
+  }) as bigint;
+
+  const transaction = await client.getTransaction({hash: txId as TransactionHash});
+  const txStatus = Number(transaction.status);
+
+  return publicClient.readContract({
+    address: client.chain.feeManagerContract.address as `0x${string}`,
+    abi: client.chain.feeManagerContract.abi as Abi,
+    functionName: "calculateMinAppealBond",
+    args: [txId, roundNumber, txStatus],
+  }) as Promise<bigint>;
+};
+
+const _encodeTopUpFeesData = ({
+  txId,
+  distribution,
+}: {
+  txId: `0x${string}`;
+  distribution: FeesDistributionInput;
+}): `0x${string}` => {
+  return encodeFunctionData({
+    abi: CONSENSUS_FEE_MANAGEMENT_ABI,
+    functionName: "topUpFees",
+    args: [txId, createFeesDistribution(distribution)],
+  });
+};
+
+const _encodeTopUpAndSubmitAppealData = ({
+  txId,
+  distribution,
+}: {
+  txId: `0x${string}`;
+  distribution: FeesDistributionInput;
+}): `0x${string}` => {
+  return encodeFunctionData({
+    abi: CONSENSUS_FEE_MANAGEMENT_ABI,
+    functionName: "topUpAndSubmitAppeal",
+    args: [txId, createFeesDistribution(distribution)],
+  });
+};
+
 /**
  * Sends a pre-encoded call to the consensus main contract, bypassing the
  * NewTransaction/CreatedTransaction log extraction used by _sendTransaction.
  * Used for consensus admin calls (appeal, finalize, etc.) that operate on
  * existing GenLayer transactions rather than creating new ones.
- * Returns the EVM transaction hash.
+ * Returns the backend RPC hash: an EVM transaction hash on network backends,
+ * or the target GenLayer tx id on Studio/localnet fee-management calls.
  */
 const _sendConsensusCall = async ({
   client,
@@ -636,6 +1836,9 @@ const _sendConsensusCall = async ({
     };
     const serializedTransaction = await validatedAccount.signTransaction(txRequest);
     const evmHash = await client.sendRawTransaction({serializedTransaction});
+    if (client.chain.isStudio) {
+      return evmHash;
+    }
     const receipt = await publicClient.waitForTransactionReceipt({hash: evmHash});
     if (receipt.status === "reverted") {
       throw new Error(`${operationName} reverted: EVM tx ${evmHash}`);
@@ -653,6 +1856,9 @@ const _sendConsensusCall = async ({
       gas: `0x${estimatedGas.toString(16)}` as `0x${string}`,
     }],
   })) as `0x${string}`;
+  if (client.chain.isStudio) {
+    return evmHash;
+  }
   const receipt = await publicClient.waitForTransactionReceipt({hash: evmHash});
   if (receipt.status === "reverted") {
     throw new Error(`${operationName} reverted: EVM tx ${evmHash}`);
@@ -734,35 +1940,73 @@ const extractTxIdFromLogs = (
 const _sendTransaction = async ({
   client,
   publicClient,
-  encodedData,
-  fallbackEncodedData,
+  transactionVariants,
   senderAccount,
-  value = 0n,
 }: {
   client: GenLayerClient<GenLayerChain>;
   publicClient: PublicClient;
-  encodedData: `0x${string}`;
-  fallbackEncodedData?: `0x${string}`;
+  transactionVariants: EncodedTransactionVariant[];
   senderAccount?: Account;
-  value?: bigint;
 }) => {
   if (!client.chain.consensusMainContract?.address) {
     throw new Error(`Consensus main contract address not found in chain config for "${client.chain.name}".`);
+  }
+  if (transactionVariants.length === 0) {
+    throw new Error("No transaction variants available to send.");
   }
 
   const validatedSenderAccount = validateAccount(senderAccount);
   const nonce = await client.getCurrentNonce({address: validatedSenderAccount.address});
 
-  const sendWithEncodedData = async (encodedDataForSend: `0x${string}`) => {
+  const knownRevertSelectorNames: Record<string, string> = {
+    "0x8d53e553": "InsufficientFees",
+    "0xb4132db3": "MaxPriceExceeded",
+    "0x57df8523": "ExecutionBudgetExceeded",
+  };
+
+  const stringifyRpcError = (error: unknown): string => {
+    const parts: string[] = [];
+    if (error instanceof Error) {
+      parts.push(error.message);
+    }
+    const record = error && typeof error === "object" ? error as Record<string, unknown> : {};
+    for (const key of ["details", "shortMessage", "data"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim() !== "") {
+        parts.push(value);
+      }
+    }
+    const cause = record.cause;
+    if (cause && typeof cause === "object") {
+      const causeRecord = cause as Record<string, unknown>;
+      for (const key of ["message", "data"]) {
+        const value = causeRecord[key];
+        if (typeof value === "string" && value.trim() !== "") {
+          parts.push(value);
+        }
+      }
+    }
+    const text = Array.from(new Set(parts)).join(" ");
+    const selectorName = Object.entries(knownRevertSelectorNames)
+      .find(([selector]) => text.includes(selector))?.[1];
+    return selectorName && !text.includes(selectorName)
+      ? `${text} (${selectorName})`
+      : text;
+  };
+
+  const sendWithEncodedData = async (transactionVariant: EncodedTransactionVariant) => {
     let estimatedGas: bigint;
+    let gasEstimationError: string | undefined;
     try {
       estimatedGas = await client.estimateTransactionGas({
         from: validatedSenderAccount.address,
         to: client.chain.consensusMainContract?.address as Address,
-        data: encodedDataForSend,
-        value: value,
+        data: transactionVariant.encodedData,
+        value: transactionVariant.value,
       });
+      estimatedGas = withTransactionGasHeadroom(estimatedGas);
     } catch (err) {
+      gasEstimationError = stringifyRpcError(err);
       console.error("Gas estimation failed, using default 200_000:", err);
       estimatedGas = 200_000n;
     }
@@ -781,10 +2025,10 @@ const _sendTransaction = async ({
       const transactionRequest = {
         account: validatedSenderAccount,
         to: client.chain.consensusMainContract?.address as Address,
-        data: encodedDataForSend,
+        data: transactionVariant.encodedData,
         type: "legacy" as const,
         nonce: Number(nonce),
-        value: value,
+        value: transactionVariant.value,
         gas: estimatedGas,
         gasPrice: BigInt(gasPriceHex),
         chainId: client.chain.id,
@@ -795,7 +2039,11 @@ const _sendTransaction = async ({
       const receipt = await publicClient.waitForTransactionReceipt({hash: txHash});
 
       if (receipt.status === "reverted") {
-        throw new Error(`Transaction reverted: EVM tx ${txHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.`);
+        throw new Error(
+          `Transaction reverted: EVM tx ${txHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.${
+            gasEstimationError ? ` Gas estimation error: ${gasEstimationError}` : ""
+          }`,
+        );
       }
 
       const txId = extractTxIdFromLogs(client, receipt.logs);
@@ -833,8 +2081,8 @@ const _sendTransaction = async ({
     const formattedRequest = {
       from: validatedSenderAccount.address,
       to: client.chain.consensusMainContract?.address as Address,
-      data: encodedDataForSend,
-      value: `0x${value.toString(16)}`,
+      data: transactionVariant.encodedData,
+      value: `0x${transactionVariant.value.toString(16)}`,
       gas: `0x${estimatedGas.toString(16)}`,
       nonce: `0x${nonceBigInt.toString(16)}`,
       type: "0x0", // legacy tx
@@ -858,7 +2106,11 @@ const _sendTransaction = async ({
     const externalReceipt = await publicClient.waitForTransactionReceipt({hash: evmTxHash});
 
     if (externalReceipt.status === "reverted") {
-      throw new Error(`Transaction reverted: EVM tx ${evmTxHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.`);
+      throw new Error(
+        `Transaction reverted: EVM tx ${evmTxHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.${
+          gasEstimationError ? ` Gas estimation error: ${gasEstimationError}` : ""
+        }`,
+      );
     }
 
     const externalTxId = extractTxIdFromLogs(client, externalReceipt.logs);
@@ -871,12 +2123,15 @@ const _sendTransaction = async ({
     return externalTxId;
   };
 
-  try {
-    return await sendWithEncodedData(encodedData);
-  } catch (error) {
-    if (!fallbackEncodedData || !isAddTransactionAbiMismatchError(error)) {
-      throw error;
+  for (let i = 0; i < transactionVariants.length; i++) {
+    try {
+      return await sendWithEncodedData(transactionVariants[i]);
+    } catch (error) {
+      if (i === transactionVariants.length - 1 || !isAddTransactionAbiMismatchError(error)) {
+        throw error;
+      }
     }
-    return await sendWithEncodedData(fallbackEncodedData);
   }
+
+  throw new Error("Unable to send transaction.");
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export {
 } from "./transactions/decoders";
 export * as chains from "./chains";
 export * as abi from "./abi";
+export * from "./transactions/fees";
 export {parseStakingAmount, formatStakingAmount} from "./staking";
 export {buildGenVmPositionalArgs} from "./contracts/schema";

--- a/src/transactions/fees.ts
+++ b/src/transactions/fees.ts
@@ -1,0 +1,226 @@
+import {encodeAbiParameters, hexToBytes, keccak256, toHex, type Hex} from "viem";
+
+import {
+  BigNumberish,
+  ExternalMessageFeeParamsInput,
+  FeesDistribution,
+  FeesDistributionInput,
+  InternalMessageFeeParamsInput,
+  MessageFeeAllocationInput,
+  MessageFeeAllocationNode,
+  MessageType,
+  TransactionFeeOptions,
+} from "@/types";
+
+export const MESSAGE_ALLOCATION_ROOT_PARENT_INDEX = (1n << 256n) - 1n;
+export const CALL_KEY_WILDCARD = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+export const CALL_KEY_UNNAMED = CALL_KEY_WILDCARD;
+export const CALL_KEY_DEPLOY = CALL_KEY_WILDCARD;
+
+const bytesToPaddedCallKey = (bytes: Uint8Array): Hex => {
+  if (bytes.length > 32) {
+    throw new Error("call key source bytes must be 32 bytes or fewer.");
+  }
+  return `0x${toHex(bytes).slice(2).padEnd(64, "0")}` as Hex;
+};
+
+export const deriveInternalMessageCallKey = (methodName = ""): Hex => {
+  const methodBytes = new TextEncoder().encode(methodName);
+  if (methodBytes.length < 32) {
+    return bytesToPaddedCallKey(methodBytes);
+  }
+
+  const hashed = keccak256(methodBytes);
+  const lastByte = Number.parseInt(hashed.slice(-2), 16) | 1;
+  return `${hashed.slice(0, -2)}${lastByte.toString(16).padStart(2, "0")}` as Hex;
+};
+
+export const deriveExternalMessageCallKey = (selectorOrCalldata: Hex | Uint8Array = "0x"): Hex => {
+  const bytes = typeof selectorOrCalldata === "string"
+    ? hexToBytes(selectorOrCalldata)
+    : selectorOrCalldata;
+
+  if (bytes.length < 4) {
+    return CALL_KEY_UNNAMED;
+  }
+
+  return bytesToPaddedCallKey(bytes.slice(0, 4));
+};
+
+export const DEFAULT_FEES_DISTRIBUTION: FeesDistribution = {
+  leaderTimeunitsAllocation: 0n,
+  validatorTimeunitsAllocation: 0n,
+  appealRounds: 0n,
+  executionBudgetPerRound: 0n,
+  executionConsumed: 0n,
+  totalMessageFees: 0n,
+  rotations: [0n],
+  maxPriceGenPerTimeUnit: 0n,
+  storageFeeMaxGasPrice: 0n,
+  receiptFeeMaxGasPrice: 0n,
+};
+
+export type NormalizedTransactionFees = {
+  distribution: FeesDistribution;
+  messageAllocations: MessageFeeAllocationNode[];
+  feeValue?: bigint;
+  requiresFeeAwareTransaction: boolean;
+};
+
+const toUInt = (value: BigNumberish | undefined, fieldName: string, fallback = 0n): bigint => {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new Error(`${fieldName} must be a safe integer when provided as a number.`);
+  }
+
+  const normalized = BigInt(value);
+  if (normalized < 0n) {
+    throw new Error(`${fieldName} must be greater than or equal to zero.`);
+  }
+  return normalized;
+};
+
+const normalizeRotations = (
+  rotations: BigNumberish[] | undefined,
+  appealRounds: bigint,
+  fieldName: string,
+): bigint[] => {
+  const expectedLength = Number(appealRounds + 1n);
+  if (!Number.isSafeInteger(expectedLength)) {
+    throw new Error(`${fieldName} appealRounds is too large.`);
+  }
+
+  if (!rotations) {
+    return Array.from({length: expectedLength}, () => 0n);
+  }
+
+  const normalized = rotations.map((rotation, index) => toUInt(rotation, `${fieldName}[${index}]`));
+  if (normalized.length !== expectedLength) {
+    throw new Error(`${fieldName} must contain appealRounds + 1 entries.`);
+  }
+  return normalized;
+};
+
+const hasNonDefaultFeesDistribution = (distribution: FeesDistribution): boolean => {
+  return (
+    distribution.leaderTimeunitsAllocation !== 0n ||
+    distribution.validatorTimeunitsAllocation !== 0n ||
+    distribution.appealRounds !== 0n ||
+    distribution.executionBudgetPerRound !== 0n ||
+    distribution.executionConsumed !== 0n ||
+    distribution.totalMessageFees !== 0n ||
+    distribution.rotations.length !== 1 ||
+    distribution.rotations[0] !== 0n ||
+    distribution.maxPriceGenPerTimeUnit !== 0n ||
+    distribution.storageFeeMaxGasPrice !== 0n ||
+    distribution.receiptFeeMaxGasPrice !== 0n
+  );
+};
+
+export const createFeesDistribution = (input: FeesDistributionInput = {}): FeesDistribution => {
+  const appealRounds = toUInt(input.appealRounds, "fees.distribution.appealRounds");
+  return {
+    leaderTimeunitsAllocation: toUInt(input.leaderTimeunitsAllocation, "fees.distribution.leaderTimeunitsAllocation"),
+    validatorTimeunitsAllocation: toUInt(input.validatorTimeunitsAllocation, "fees.distribution.validatorTimeunitsAllocation"),
+    appealRounds,
+    executionBudgetPerRound: toUInt(input.executionBudgetPerRound, "fees.distribution.executionBudgetPerRound"),
+    executionConsumed: toUInt(input.executionConsumed, "fees.distribution.executionConsumed"),
+    totalMessageFees: toUInt(input.totalMessageFees, "fees.distribution.totalMessageFees"),
+    rotations: normalizeRotations(input.rotations, appealRounds, "fees.distribution.rotations"),
+    maxPriceGenPerTimeUnit: toUInt(input.maxPriceGenPerTimeUnit, "fees.distribution.maxPriceGenPerTimeUnit"),
+    storageFeeMaxGasPrice: toUInt(input.storageFeeMaxGasPrice, "fees.distribution.storageFeeMaxGasPrice"),
+    receiptFeeMaxGasPrice: toUInt(input.receiptFeeMaxGasPrice, "fees.distribution.receiptFeeMaxGasPrice"),
+  };
+};
+
+export const encodeInternalMessageFeeParams = (input: InternalMessageFeeParamsInput = {}) => {
+  const appealRounds = toUInt(input.appealRounds, "internalMessageFeeParams.appealRounds");
+  return encodeAbiParameters(
+    [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          {name: "leaderTimeunitsAllocation", type: "uint256"},
+          {name: "validatorTimeunitsAllocation", type: "uint256"},
+          {name: "appealRounds", type: "uint256"},
+          {name: "executionBudgetPerRound", type: "uint256"},
+          {name: "rotations", type: "uint256[]"},
+        ],
+      },
+    ],
+    [
+      {
+        leaderTimeunitsAllocation: toUInt(input.leaderTimeunitsAllocation, "internalMessageFeeParams.leaderTimeunitsAllocation"),
+        validatorTimeunitsAllocation: toUInt(input.validatorTimeunitsAllocation, "internalMessageFeeParams.validatorTimeunitsAllocation"),
+        appealRounds,
+        executionBudgetPerRound: toUInt(input.executionBudgetPerRound, "internalMessageFeeParams.executionBudgetPerRound"),
+        rotations: normalizeRotations(input.rotations, appealRounds, "internalMessageFeeParams.rotations"),
+      },
+    ],
+  );
+};
+
+export const encodeExternalMessageFeeParams = (input: ExternalMessageFeeParamsInput = {}) => {
+  return encodeAbiParameters(
+    [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          {name: "gasLimit", type: "uint256"},
+          {name: "maxGasPrice", type: "uint256"},
+        ],
+      },
+    ],
+    [
+      {
+        gasLimit: toUInt(input.gasLimit, "externalMessageFeeParams.gasLimit"),
+        maxGasPrice: toUInt(input.maxGasPrice, "externalMessageFeeParams.maxGasPrice"),
+      },
+    ],
+  );
+};
+
+export const normalizeMessageFeeAllocations = (
+  allocations: MessageFeeAllocationInput[] = [],
+): MessageFeeAllocationNode[] => {
+  return allocations.map((allocation, index) => ({
+    messageType: allocation.messageType,
+    onAcceptance: allocation.onAcceptance ?? allocation.messageType !== MessageType.External,
+    parentIndex: toUInt(
+      allocation.parentIndex,
+      `fees.messageAllocations[${index}].parentIndex`,
+      MESSAGE_ALLOCATION_ROOT_PARENT_INDEX,
+    ),
+    recipient: allocation.recipient,
+    callKey: allocation.callKey ?? CALL_KEY_WILDCARD,
+    budget: toUInt(allocation.budget, `fees.messageAllocations[${index}].budget`),
+    feeParams: allocation.feeParams ?? "0x",
+  }));
+};
+
+export const normalizeTransactionFees = (fees?: TransactionFeeOptions): NormalizedTransactionFees => {
+  const distribution = createFeesDistribution(fees?.distribution);
+  const messageAllocations = normalizeMessageFeeAllocations(fees?.messageAllocations);
+  const feeValue = fees?.feeValue === undefined
+    ? undefined
+    : toUInt(fees.feeValue, "fees.feeValue");
+
+  return {
+    distribution,
+    messageAllocations,
+    feeValue,
+    requiresFeeAwareTransaction:
+      hasNonDefaultFeesDistribution(distribution) ||
+      messageAllocations.length > 0 ||
+      (feeValue ?? 0n) !== 0n,
+  };
+};
+
+export {
+  MessageType,
+};

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -1,5 +1,20 @@
 import {Transport, Client, PublicActions, WalletActions} from "viem";
-import {GenLayerTransaction, TransactionHash, TransactionStatus, TransactionHashVariant, DebugTraceResult} from "./transactions";
+import {
+  GenLayerTransaction,
+  TransactionHash,
+  TransactionStatus,
+  TransactionHashVariant,
+  DebugTraceResult,
+  TransactionFeeOptions,
+  TransactionFeeEstimate,
+  FeeEstimateOptions,
+  SimulationFeeEstimateOptions,
+  WriteFeeEstimateOptions,
+  FeePolicyQuote,
+  BigNumberish,
+  FeesDistributionInput,
+  SimulateWriteContractResult,
+} from "./transactions";
 import {GenLayerChain} from "./chains";
 import {Address, Account} from "./accounts";
 import {CalldataEncodable} from "./calldata";
@@ -21,7 +36,10 @@ export type GenLayerMethod =
   | {method: "eth_getTransactionCount"; params: [address: Address, block: string]}
   | {method: "eth_estimateGas"; params: [transactionParams: any]}
   | {method: "gen_call"; params: [requestParams: any]}
-  | {method: "sim_cancelTransaction"; params: [hash: TransactionHash, signature?: string, adminKey?: string]};
+  | {method: "sim_call"; params: [requestParams: any]}
+  | {method: "sim_estimateTransactionFees"; params: [requestParams: any]}
+  | {method: "sim_cancelTransaction"; params: [hash: TransactionHash, signature?: string, adminKey?: string]}
+  | {method: "sim_getFeeConfig"; params: []};
 
 /*
   Take all the properties from Client<Transport, TGenLayerChain>
@@ -58,20 +76,30 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       functionName: string;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
-      value: bigint;
+      value?: bigint;
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
+      validUntil?: BigNumberish;
+      fees?: TransactionFeeOptions;
     }) => Promise<any>;
-    simulateWriteContract: <RawReturn extends boolean | undefined>(args: {
+    simulateWriteContract: <
+      RawReturn extends boolean | undefined = undefined,
+      IncludeReceipt extends boolean | undefined = undefined,
+    >(args: {
       account?: Account;
       address: Address;
       functionName: string;
       args?: CalldataEncodable[];
       kwargs?: Map<string, CalldataEncodable> | { [key: string]: CalldataEncodable };
       rawReturn?: RawReturn;
+      includeReceipt?: IncludeReceipt;
+      value?: BigNumberish;
       leaderOnly?: boolean;
+      fees?: TransactionFeeOptions;
       transactionHashVariant?: TransactionHashVariant;
-    }) => Promise<RawReturn extends true ? `0x${string}` : CalldataEncodable>;
+    }) => Promise<IncludeReceipt extends true
+      ? SimulateWriteContractResult<RawReturn>
+      : RawReturn extends true ? `0x${string}` : CalldataEncodable>;
     deployContract: (args: {
       account?: Account;
       code: string | Uint8Array;
@@ -79,6 +107,8 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
       leaderOnly?: boolean;
       consensusMaxRotations?: number;
+      validUntil?: BigNumberish;
+      fees?: TransactionFeeOptions;
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: Address}) => Promise<number>;
@@ -114,6 +144,18 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       txId: `0x${string}`;
       value?: bigint;
     }) => Promise<any>;
+    topUpFees: (args: {
+      account?: Account;
+      txId: `0x${string}`;
+      distribution: FeesDistributionInput;
+      value: bigint;
+    }) => Promise<`0x${string}`>;
+    topUpAndSubmitAppeal: (args: {
+      account?: Account;
+      txId: `0x${string}`;
+      distribution: FeesDistributionInput;
+      value?: bigint;
+    }) => Promise<`0x${string}`>;
     finalizeTransaction: (args: {
       account?: Account;
       txId: `0x${string}`;
@@ -123,4 +165,9 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       txIds: readonly `0x${string}`[];
     }) => Promise<`0x${string}`>;
     getMinAppealBond: (args: {txId: `0x${string}`}) => Promise<bigint>;
+    getCurrentFeePolicy: () => Promise<FeePolicyQuote>;
+    estimateFeesDistribution: (args?: FeeEstimateOptions) => Promise<TransactionFeeEstimate["distribution"]>;
+    estimateTransactionFees: (args?: FeeEstimateOptions) => Promise<TransactionFeeEstimate>;
+    estimateTransactionFeesFromSimulation: (args: SimulationFeeEstimateOptions) => Promise<TransactionFeeEstimate>;
+    estimateTransactionFeesForWrite: (args: WriteFeeEstimateOptions) => Promise<TransactionFeeEstimate>;
   } & StakingActions;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,8 +1,10 @@
 import {Hex} from "viem";
-import {Address} from "./accounts";
+import {Account, Address} from "./accounts";
+import type {CalldataEncodable} from "./calldata";
 
 export type Hash = `0x${string}` & {length: 66};
 export type TransactionHash = Hash;
+export type BigNumberish = bigint | number | string;
 
 export enum TransactionStatus {
   UNINITIALIZED = "UNINITIALIZED",
@@ -150,6 +152,271 @@ export enum TransactionHashVariant {
   LATEST_FINAL = "latest-final",
   LATEST_NONFINAL = "latest-nonfinal",
 }
+
+export enum MessageType {
+  External = 0,
+  Internal = 1,
+}
+
+export type FeesDistribution = {
+  leaderTimeunitsAllocation: bigint;
+  validatorTimeunitsAllocation: bigint;
+  appealRounds: bigint;
+  executionBudgetPerRound: bigint;
+  executionConsumed: bigint;
+  totalMessageFees: bigint;
+  rotations: bigint[];
+  maxPriceGenPerTimeUnit: bigint;
+  storageFeeMaxGasPrice: bigint;
+  receiptFeeMaxGasPrice: bigint;
+};
+
+export type FeesDistributionInput = {
+  leaderTimeunitsAllocation?: BigNumberish;
+  validatorTimeunitsAllocation?: BigNumberish;
+  appealRounds?: BigNumberish;
+  executionBudgetPerRound?: BigNumberish;
+  executionConsumed?: BigNumberish;
+  totalMessageFees?: BigNumberish;
+  rotations?: BigNumberish[];
+  maxPriceGenPerTimeUnit?: BigNumberish;
+  storageFeeMaxGasPrice?: BigNumberish;
+  receiptFeeMaxGasPrice?: BigNumberish;
+};
+
+export type InternalMessageFeeParamsInput = {
+  leaderTimeunitsAllocation?: BigNumberish;
+  validatorTimeunitsAllocation?: BigNumberish;
+  appealRounds?: BigNumberish;
+  executionBudgetPerRound?: BigNumberish;
+  rotations?: BigNumberish[];
+};
+
+export type ExternalMessageFeeParamsInput = {
+  gasLimit?: BigNumberish;
+  maxGasPrice?: BigNumberish;
+};
+
+export type MessageFeeAllocationNode = {
+  messageType: MessageType;
+  onAcceptance: boolean;
+  parentIndex: bigint;
+  recipient: Address;
+  callKey: Hex;
+  budget: bigint;
+  feeParams: Hex;
+};
+
+export type MessageFeeAllocationInput = {
+  messageType: MessageType;
+  onAcceptance?: boolean;
+  parentIndex?: BigNumberish;
+  recipient: Address;
+  callKey?: Hex;
+  budget?: BigNumberish;
+  feeParams?: Hex;
+};
+
+export type TransactionFeeOptions = {
+  distribution?: FeesDistributionInput;
+  messageAllocations?: MessageFeeAllocationInput[];
+  feeValue?: BigNumberish;
+};
+
+export type FeePolicyQuote = {
+  enabled: boolean;
+  genPerTimeUnit: bigint;
+  storageUnitPrice: bigint;
+  receiptGasPrice: bigint;
+  executionBudgetFloor: bigint;
+};
+
+export type FeeEstimateOptions = FeesDistributionInput & {
+  /**
+   * Basis-points multiplier applied to current network prices when filling
+   * unset cap fields. Defaults to 12000 (20% headroom).
+   */
+  priceCapHeadroomBps?: BigNumberish;
+  messageAllocations?: MessageFeeAllocationInput[];
+};
+
+export type TransactionFeeEstimate = {
+  distribution: FeesDistribution;
+  messageAllocations?: MessageFeeAllocationInput[];
+  feeValue: bigint;
+  policy: FeePolicyQuote;
+  observed?: SimulationFeeUsage;
+};
+
+export type SimulateWriteContractReceipt = Record<string, unknown>;
+
+export type StudioExecutionFeeReportMessage = {
+  messageFeeMode?: "mode1" | "mode2" | "external";
+  messageType: "External" | "Internal";
+  recipient: Address;
+  value: BigNumberish;
+  dataBytes: BigNumberish;
+  onAcceptance: boolean;
+  saltNonce: BigNumberish;
+  feeParams?: Hex;
+  feeParamsDecoded?: InternalMessageFeeParamsInput | ExternalMessageFeeParamsInput | null;
+  feeParamsBytes: BigNumberish;
+  declaredBudget: BigNumberish;
+  allocationSubtree?: Hex;
+  allocationSubtreeBytes: BigNumberish;
+  callKey: Hex;
+};
+
+export type StudioGenvmFeeBucket = {
+  index?: BigNumberish;
+  name?: string;
+  consumed?: BigNumberish;
+};
+
+export type StudioGenvmFeeBucketReport = {
+  receiptAndNondetOutput?: BigNumberish;
+  storage?: BigNumberish;
+  message?: BigNumberish;
+  totalExecution?: BigNumberish;
+  totalWithMessage?: BigNumberish;
+  executionBudgetPerRound?: BigNumberish;
+  executionBudgetRemaining?: BigNumberish;
+  executionBudgetOverrun?: BigNumberish;
+  executionBudgetExceeded?: boolean;
+  buckets?: StudioGenvmFeeBucket[];
+};
+
+export type StudioExecutionFeeReport = {
+  receiptGasPrice?: BigNumberish;
+  budgetExhaustionReason?: string | null;
+  proposalReceipt?: {
+    eqBlocksOutputsLength: BigNumberish;
+    receiptBytes: BigNumberish;
+    estimatedGas: BigNumberish;
+    fee: BigNumberish;
+  };
+  messageReveal?: {
+    messageBytes: BigNumberish;
+    messageCount: BigNumberish;
+    estimatedGas: BigNumberish;
+    fee: BigNumberish;
+    consensusAdditionalGas?: BigNumberish;
+    consensusAdditionalFee?: BigNumberish;
+    studioFixedOverheadGas?: BigNumberish;
+    studioFixedOverheadFee?: BigNumberish;
+    messages?: StudioExecutionFeeReportMessage[];
+  };
+  genvmBuckets?: StudioGenvmFeeBucketReport;
+  chargeableExecution?: StudioGenvmFeeBucketReport;
+  executionMetering?: {
+    chargeableExecutionFee?: BigNumberish;
+    genvmReportedExecution?: BigNumberish;
+    genvmDeltaFromChargeable?: BigNumberish;
+  };
+  messageFees?: {
+    budget?: BigNumberish;
+    declaredConsumed?: BigNumberish;
+    genvmMeteredConsumed?: BigNumberish;
+    externalReserved?: BigNumberish;
+    externalReimbursed?: BigNumberish;
+    externalRemainder?: BigNumberish;
+    totalConsumed?: BigNumberish;
+    declaredRefunded?: BigNumberish;
+    remaining?: BigNumberish;
+    meteringDelta?: BigNumberish;
+    reportedTotal?: BigNumberish;
+  };
+  totalEstimatedFee?: BigNumberish;
+  totalStudioMeteredFee?: BigNumberish;
+};
+
+export type StudioFeeAccounting = Record<string, unknown> & {
+  paid_fee_value?: BigNumberish;
+  required_fee_value?: BigNumberish;
+  primary_fee_required?: BigNumberish;
+  primary_fee_budget?: BigNumberish;
+  primary_fee_spent?: BigNumberish;
+  primary_fee_refunded?: BigNumberish;
+  execution_budget_total?: BigNumberish;
+  execution_fee_consumed?: BigNumberish;
+  execution_fee_consumed_buckets?: BigNumberish[];
+  genvm_fee_consumed_buckets?: BigNumberish[];
+  genvm_fee_bucket_report?: StudioGenvmFeeBucketReport;
+  genvm_message_fee_consumed?: BigNumberish;
+  message_fee_budget?: BigNumberish;
+  message_fee_consumed?: BigNumberish;
+  message_fee_refunded?: BigNumberish;
+  external_message_fee_reserved?: BigNumberish;
+  external_message_fee_reimbursed?: BigNumberish;
+  external_message_fee_remainder?: BigNumberish;
+  appeal_bonds_total?: BigNumberish;
+  total_refunded?: BigNumberish;
+  fees_distribution?: FeesDistributionInput;
+  message_allocations?: MessageFeeAllocationInput[];
+  execution_fee_report?: StudioExecutionFeeReport;
+};
+
+export type SimulateWriteContractResult<
+  RawReturn extends boolean | undefined = undefined,
+> = {
+  result: RawReturn extends true ? Hex : CalldataEncodable;
+  receipt: SimulateWriteContractReceipt;
+  feeAccounting?: StudioFeeAccounting;
+  feeReport?: StudioExecutionFeeReport;
+};
+
+export type SimulationFeeUsage = {
+  executionFeeConsumed: bigint;
+  executionFeeReportTotal: bigint;
+  recommendedExecutionBudgetPerRound: bigint;
+  genvmMessageFeeConsumed: bigint;
+  messageFeeBudget: bigint;
+  messageFeeConsumed: bigint;
+  messageFeeRefunded: bigint;
+  internalDeclaredBudget: bigint;
+  externalMessageReserved: bigint;
+  externalMessageReimbursed: bigint;
+  externalMessageRemainder: bigint;
+  recommendedTotalMessageFees: bigint;
+};
+
+export type SimulationFeeEstimateOptions = FeeEstimateOptions & {
+  simulation: Pick<
+    SimulateWriteContractResult<boolean | undefined>,
+    "feeAccounting" | "feeReport"
+  >;
+  /**
+   * Basis-points multiplier applied to observed execution fee usage.
+   * Defaults to 12000 (20% headroom).
+   */
+  executionHeadroomBps?: BigNumberish;
+  /**
+   * Basis-points multiplier applied to observed mode-1 message fee usage.
+   * Defaults to 12000 (20% headroom).
+   */
+  messageHeadroomBps?: BigNumberish;
+};
+
+export type WriteFeeEstimateOptions = FeeEstimateOptions & {
+  account?: Account;
+  address: Address;
+  functionName: string;
+  args?: CalldataEncodable[];
+  kwargs?: Map<string, CalldataEncodable> | {[key: string]: CalldataEncodable};
+  value?: BigNumberish;
+  leaderOnly?: boolean;
+  transactionHashVariant?: TransactionHashVariant;
+  /**
+   * Basis-points multiplier applied to observed execution fee usage.
+   * Defaults to 12000 (20% headroom).
+   */
+  executionHeadroomBps?: BigNumberish;
+  /**
+   * Basis-points multiplier applied to observed mode-1 message fee usage.
+   * Defaults to 12000 (20% headroom).
+   */
+  messageHeadroomBps?: BigNumberish;
+};
 
 export type DecodedDeployData = {
   code?: Hex;

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -1,6 +1,15 @@
 import {describe, it, expect, vi} from "vitest";
-import {encodeFunctionData, keccak256, toHex} from "viem";
+import {decodeAbiParameters, decodeFunctionData, encodeFunctionData, keccak256, toHex} from "viem";
 import {contractActions} from "../src/contracts/actions";
+import {
+  CALL_KEY_DEPLOY,
+  CALL_KEY_WILDCARD,
+  deriveExternalMessageCallKey,
+  deriveInternalMessageCallKey,
+  encodeExternalMessageFeeParams,
+  encodeInternalMessageFeeParams,
+  MessageType,
+} from "../src/transactions/fees";
 
 const MAIN_CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000001";
 const SENDER_ADDRESS = "0x0000000000000000000000000000000000000002";
@@ -81,6 +90,81 @@ const ADD_TRANSACTION_ABI_V6 = [
   },
 ] as const;
 
+const FEES_DISTRIBUTION_COMPONENTS = [
+  {name: "leaderTimeunitsAllocation", type: "uint256"},
+  {name: "validatorTimeunitsAllocation", type: "uint256"},
+  {name: "appealRounds", type: "uint256"},
+  {name: "executionBudgetPerRound", type: "uint256"},
+  {name: "executionConsumed", type: "uint256"},
+  {name: "totalMessageFees", type: "uint256"},
+  {name: "rotations", type: "uint256[]"},
+  {name: "maxPriceGenPerTimeUnit", type: "uint256"},
+  {name: "storageFeeMaxGasPrice", type: "uint256"},
+  {name: "receiptFeeMaxGasPrice", type: "uint256"},
+] as const;
+
+const MESSAGE_FEE_ALLOCATION_COMPONENTS = [
+  {name: "messageType", type: "uint8"},
+  {name: "onAcceptance", type: "bool"},
+  {name: "parentIndex", type: "uint256"},
+  {name: "recipient", type: "address"},
+  {name: "callKey", type: "bytes32"},
+  {name: "budget", type: "uint256"},
+  {name: "feeParams", type: "bytes"},
+] as const;
+
+const INTERNAL_MESSAGE_FEE_PARAMS_ABI = [
+  {
+    name: "params",
+    type: "tuple",
+    components: [
+      {name: "leaderTimeunitsAllocation", type: "uint256"},
+      {name: "validatorTimeunitsAllocation", type: "uint256"},
+      {name: "appealRounds", type: "uint256"},
+      {name: "executionBudgetPerRound", type: "uint256"},
+      {name: "rotations", type: "uint256[]"},
+    ],
+  },
+] as const;
+
+const EXTERNAL_MESSAGE_FEE_PARAMS_ABI = [
+  {
+    name: "params",
+    type: "tuple",
+    components: [
+      {name: "gasLimit", type: "uint256"},
+      {name: "maxGasPrice", type: "uint256"},
+    ],
+  },
+] as const;
+
+const ADD_TRANSACTION_ABI_WITH_FEES = [
+  {
+    type: "function",
+    name: "addTransaction",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "_params",
+        type: "tuple",
+        components: [
+          {name: "sender", type: "address"},
+          {name: "recipient", type: "address"},
+          {name: "numOfInitialValidators", type: "uint256"},
+          {name: "maxRotations", type: "uint256"},
+          {name: "validUntil", type: "uint256"},
+          {name: "saltNonce", type: "uint256"},
+          {name: "userValue", type: "uint256"},
+          {name: "feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+          {name: "txCalldata", type: "bytes"},
+          {name: "messageAllocations", type: "tuple[]", components: MESSAGE_FEE_ALLOCATION_COMPONENTS},
+        ],
+      },
+    ],
+    outputs: [],
+  },
+] as const;
+
 const selectorForV5 = encodeFunctionData({
   abi: ADD_TRANSACTION_ABI_V5 as any,
   functionName: "addTransaction",
@@ -93,12 +177,48 @@ const selectorForV6 = encodeFunctionData({
   args: [SENDER_ADDRESS, RECIPIENT_ADDRESS, 5, 3, "0x", 0n],
 }).slice(0, 10);
 
+const selectorForFees = encodeFunctionData({
+  abi: ADD_TRANSACTION_ABI_WITH_FEES as any,
+  functionName: "addTransaction",
+  args: [{
+    sender: SENDER_ADDRESS,
+    recipient: RECIPIENT_ADDRESS,
+    numOfInitialValidators: 5n,
+    maxRotations: 3n,
+    validUntil: 1n,
+    saltNonce: 0n,
+    userValue: 0n,
+    feesDistribution: {
+      leaderTimeunitsAllocation: 0n,
+      validatorTimeunitsAllocation: 0n,
+      appealRounds: 0n,
+      executionBudgetPerRound: 0n,
+      executionConsumed: 0n,
+      totalMessageFees: 0n,
+      rotations: [0n],
+      maxPriceGenPerTimeUnit: 0n,
+      storageFeeMaxGasPrice: 0n,
+      receiptFeeMaxGasPrice: 0n,
+    },
+    txCalldata: "0x",
+    messageAllocations: [],
+  }],
+}).slice(0, 10);
+
 const setupWriteContractHarness = ({
   initialAbi,
   signTransactionMock,
+  publicClient = {},
+  feeManagerAddress,
+  isStudio = false,
+  requestMock,
 }: {
   initialAbi: readonly unknown[];
   signTransactionMock?: ReturnType<typeof vi.fn>;
+  publicClient?: Record<string, unknown>;
+  feeManagerAddress?: string;
+  isStudio?: boolean;
+  requestMock?: ReturnType<typeof vi.fn>;
 }) => {
   const estimateTransactionGas = vi.fn().mockResolvedValue(21_000n);
   const signTransaction = signTransactionMock ?? vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
@@ -106,6 +226,7 @@ const setupWriteContractHarness = ({
   const client = {
     chain: {
       id: 61_127,
+      isStudio,
       defaultNumberOfInitialValidators: 5,
       defaultConsensusMaxRotations: 3,
       consensusMainContract: {
@@ -113,6 +234,12 @@ const setupWriteContractHarness = ({
         abi: [...initialAbi],
         bytecode: "0x",
       },
+      feeManagerContract: feeManagerAddress
+        ? {
+          address: feeManagerAddress,
+          abi: [],
+        }
+        : null,
     },
     account: {
       address: SENDER_ADDRESS,
@@ -122,7 +249,7 @@ const setupWriteContractHarness = ({
     initializeConsensusSmartContract: vi.fn().mockResolvedValue(undefined),
     getCurrentNonce: vi.fn().mockResolvedValue(0n),
     estimateTransactionGas,
-    request: vi.fn().mockImplementation(async ({method}: {method: string}) => {
+    request: requestMock ?? vi.fn().mockImplementation(async ({method}: {method: string}) => {
       if (method === "eth_gasPrice") {
         return "0x1";
       }
@@ -130,12 +257,189 @@ const setupWriteContractHarness = ({
     }),
   };
 
-  const actions = contractActions(client as any, {} as any);
+  const actions = contractActions(client as any, publicClient as any);
 
-  return {actions, estimateTransactionGas, client, signTransaction};
+  return {actions, estimateTransactionGas, client, signTransaction, publicClient};
 };
 
 describe("contractActions addTransaction ABI compatibility", () => {
+  it("passes trusted fees and user value through Studio simulateWriteContract sim_call", async () => {
+    const request = vi.fn().mockResolvedValue({
+      result: Buffer.from([0, 0xab, 0xcd]).toString("base64"),
+      execution_result: "SUCCESS",
+      genvm_result: {
+        fee_accounting: {
+          status: "active",
+          primary_fee_budget: "123",
+          execution_fee_report: {
+            receiptGasPrice: "1",
+            proposalReceipt: {
+              eqBlocksOutputsLength: "10",
+              receiptBytes: "1034",
+              estimatedGas: "314544",
+              fee: "314544",
+            },
+            messageReveal: {
+              messageBytes: "320",
+              messageCount: "1",
+              estimatedGas: "187120",
+              fee: "187120",
+              messages: [
+                {
+                  messageType: "Internal",
+                  recipient: RECIPIENT_ADDRESS,
+                  value: "0",
+                  dataBytes: "2",
+                  onAcceptance: true,
+                  saltNonce: "0",
+                  feeParamsBytes: "2",
+                  declaredBudget: "5",
+                  allocationSubtreeBytes: "0",
+                  callKey: `0x${"12".repeat(32)}`,
+                },
+              ],
+            },
+            totalEstimatedFee: "501664",
+          },
+        },
+      },
+    });
+    const actions = contractActions({
+      chain: {
+        id: 61_127,
+        defaultNumberOfInitialValidators: 5,
+        defaultConsensusMaxRotations: 3,
+        isStudio: true,
+      },
+      account: {
+        address: SENDER_ADDRESS,
+      },
+      request,
+    } as any, {} as any);
+
+    const result = await actions.simulateWriteContract({
+      address: RECIPIENT_ADDRESS,
+      functionName: "update_storage",
+      args: ["simulated"],
+      rawReturn: true,
+      includeReceipt: true,
+      value: 12n,
+      fees: {
+        feeValue: 123n,
+        distribution: {
+          leaderTimeunitsAllocation: 100n,
+          validatorTimeunitsAllocation: 200n,
+          totalMessageFees: 5n,
+          rotations: [0n],
+        },
+        messageAllocations: [
+          {
+            messageType: MessageType.Internal,
+            recipient: RECIPIENT_ADDRESS,
+            budget: 5n,
+            feeParams: "0x1234",
+          },
+        ],
+      },
+    });
+
+    expect(request.mock.calls[0][0].method).toBe("sim_call");
+    const params = request.mock.calls[0][0].params[0];
+    expect(result.result).toBe("0xabcd");
+    expect(result.feeAccounting).toEqual({
+      status: "active",
+      primary_fee_budget: "123",
+      execution_fee_report: {
+        receiptGasPrice: "1",
+        proposalReceipt: {
+          eqBlocksOutputsLength: "10",
+          receiptBytes: "1034",
+          estimatedGas: "314544",
+          fee: "314544",
+        },
+        messageReveal: {
+          messageBytes: "320",
+          messageCount: "1",
+          estimatedGas: "187120",
+          fee: "187120",
+          messages: [
+            {
+              messageType: "Internal",
+              recipient: RECIPIENT_ADDRESS,
+              value: "0",
+              dataBytes: "2",
+              onAcceptance: true,
+              saltNonce: "0",
+              feeParamsBytes: "2",
+              declaredBudget: "5",
+              allocationSubtreeBytes: "0",
+              callKey: `0x${"12".repeat(32)}`,
+            },
+          ],
+        },
+        totalEstimatedFee: "501664",
+      },
+    });
+    expect(result.feeReport?.messageReveal?.messages?.[0].declaredBudget).toBe("5");
+    expect(params.value).toBe("0xc");
+    expect(params.fees.feeValue).toBe("123");
+    expect(params.fees.distribution.leaderTimeunitsAllocation).toBe("100");
+    expect(params.fees.distribution.validatorTimeunitsAllocation).toBe("200");
+    expect(params.fees.distribution.totalMessageFees).toBe("5");
+    expect(params.fees.distribution.rotations).toEqual(["0"]);
+    expect(params.fees.messageAllocations[0].messageType).toBe(MessageType.Internal);
+    expect(params.fees.messageAllocations[0].budget).toBe("5");
+  });
+
+  it("encodes internal message fee params as the consensus tuple", () => {
+    const encoded = encodeInternalMessageFeeParams({
+      leaderTimeunitsAllocation: 5n,
+      validatorTimeunitsAllocation: 10n,
+      appealRounds: 1n,
+      executionBudgetPerRound: 20n,
+      rotations: [2n, 3n],
+    });
+
+    const [decoded] = decodeAbiParameters(INTERNAL_MESSAGE_FEE_PARAMS_ABI, encoded) as any;
+    expect(decoded.leaderTimeunitsAllocation).toBe(5n);
+    expect(decoded.validatorTimeunitsAllocation).toBe(10n);
+    expect(decoded.appealRounds).toBe(1n);
+    expect(decoded.executionBudgetPerRound).toBe(20n);
+    expect(decoded.rotations).toEqual([2n, 3n]);
+  });
+
+  it("encodes external message fee params as the consensus tuple", () => {
+    const encoded = encodeExternalMessageFeeParams({
+      gasLimit: 21_000n,
+      maxGasPrice: 10n,
+    });
+
+    const [decoded] = decodeAbiParameters(EXTERNAL_MESSAGE_FEE_PARAMS_ABI, encoded) as any;
+    expect(decoded.gasLimit).toBe(21_000n);
+    expect(decoded.maxGasPrice).toBe(10n);
+  });
+
+  it("derives GenVM-compatible message call keys", () => {
+    const shortInternal = deriveInternalMessageCallKey("update_storage");
+    expect(shortInternal).toBe(
+      `0x${Buffer.from("update_storage", "utf8").toString("hex").padEnd(64, "0")}`,
+    );
+
+    const exactLengthMethod = "a".repeat(32);
+    const hashed = keccak256(toHex(new TextEncoder().encode(exactLengthMethod)));
+    const lastByte = Number.parseInt(hashed.slice(-2), 16) | 1;
+    expect(deriveInternalMessageCallKey(exactLengthMethod)).toBe(
+      `${hashed.slice(0, -2)}${lastByte.toString(16).padStart(2, "0")}`,
+    );
+
+    expect(deriveInternalMessageCallKey()).toBe(CALL_KEY_WILDCARD);
+    expect(CALL_KEY_DEPLOY).toBe(CALL_KEY_WILDCARD);
+    expect(deriveExternalMessageCallKey("0xaabbccdd11223344")).toBe(
+      `0xaabbccdd${"0".repeat(56)}`,
+    );
+    expect(deriveExternalMessageCallKey("0x123456")).toBe(CALL_KEY_WILDCARD);
+  });
+
   it("encodes addTransaction with 5 args when ABI has 5 inputs", async () => {
     const {actions, estimateTransactionGas} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_V5,
@@ -168,6 +472,691 @@ describe("contractActions addTransaction ABI compatibility", () => {
 
     const encodedData = estimateTransactionGas.mock.calls[0][0].data as `0x${string}`;
     expect(encodedData.slice(0, 10)).toBe(selectorForV6);
+  });
+
+  it("encodes addTransaction with v0.6 fee params when ABI has tuple input", async () => {
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 7n,
+        validUntil: 123n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    const estimateParams = estimateTransactionGas.mock.calls[0][0];
+    const encodedData = estimateParams.data as `0x${string}`;
+    expect(encodedData.slice(0, 10)).toBe(selectorForFees);
+    expect(estimateParams.value).toBe(7n);
+
+    const decoded = decodeFunctionData({
+      abi: ADD_TRANSACTION_ABI_WITH_FEES as any,
+      data: encodedData,
+    });
+    const params = decoded.args[0] as any;
+    expect(params.sender).toBe(SENDER_ADDRESS);
+    expect(params.recipient).toBe(RECIPIENT_ADDRESS);
+    expect(params.numOfInitialValidators).toBe(5n);
+    expect(params.maxRotations).toBe(3n);
+    expect(params.validUntil).toBe(123n);
+    expect(params.userValue).toBe(7n);
+    expect(params.feesDistribution.rotations).toEqual([0n]);
+    expect(params.messageAllocations).toEqual([]);
+  });
+
+  it("separates user value from v0.6 fee deposit value", async () => {
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 5n,
+        validUntil: 123n,
+        fees: {
+          feeValue: 123n,
+          distribution: {
+            totalMessageFees: 123n,
+          },
+          messageAllocations: [{
+            messageType: MessageType.Internal,
+            onAcceptance: false,
+            recipient: RECIPIENT_ADDRESS,
+            budget: 123n,
+            feeParams: "0x1234",
+          }],
+        },
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    const estimateParams = estimateTransactionGas.mock.calls[0][0];
+    expect(estimateParams.value).toBe(128n);
+
+    const decoded = decodeFunctionData({
+      abi: ADD_TRANSACTION_ABI_WITH_FEES as any,
+      data: estimateParams.data as `0x${string}`,
+    });
+    const params = decoded.args[0] as any;
+    expect(params.userValue).toBe(5n);
+    expect(params.feesDistribution.totalMessageFees).toBe(123n);
+    expect(params.messageAllocations).toHaveLength(1);
+    expect(params.messageAllocations[0].messageType).toBe(MessageType.Internal);
+    expect(params.messageAllocations[0].onAcceptance).toBe(false);
+    expect(params.messageAllocations[0].budget).toBe(123n);
+    expect(params.messageAllocations[0].feeParams).toBe("0x1234");
+  });
+
+  it("defaults external message allocations to on-finalization", async () => {
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        validUntil: 123n,
+        fees: {
+          feeValue: 210_000n,
+          distribution: {
+            totalMessageFees: 210_000n,
+          },
+          messageAllocations: [{
+            messageType: MessageType.External,
+            recipient: RECIPIENT_ADDRESS,
+            budget: 210_000n,
+            feeParams: encodeExternalMessageFeeParams({
+              gasLimit: 21_000n,
+              maxGasPrice: 10n,
+            }),
+          }],
+        },
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    const decoded = decodeFunctionData({
+      abi: ADD_TRANSACTION_ABI_WITH_FEES as any,
+      data: estimateTransactionGas.mock.calls[0][0].data as `0x${string}`,
+    });
+    const params = decoded.args[0] as any;
+    expect(params.messageAllocations[0].messageType).toBe(MessageType.External);
+    expect(params.messageAllocations[0].onAcceptance).toBe(false);
+  });
+
+  it("calculates v0.6 fee deposit from FeeManager when feeValue is omitted", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue(77n),
+    };
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 2n,
+        validUntil: 123n,
+        fees: {
+          distribution: {
+            leaderTimeunitsAllocation: 10n,
+            totalMessageFees: 3n,
+          },
+        },
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(expect.objectContaining({
+      functionName: "calculateRoundFees",
+      args: [expect.any(Object), 5n, 0n],
+    }));
+    expect(estimateTransactionGas.mock.calls[0][0].value).toBe(82n);
+  });
+
+  it("calculates v0.6 fee deposit from FeeManager when only execution budget is provided", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue(500_000n),
+    };
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        validUntil: 123n,
+        fees: {
+          distribution: {
+            executionBudgetPerRound: 500_000n,
+          },
+        },
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(publicClient.readContract).toHaveBeenCalledWith(expect.objectContaining({
+      functionName: "calculateRoundFees",
+      args: [expect.any(Object), 5n, 0n],
+    }));
+    expect(estimateTransactionGas.mock.calls[0][0].value).toBe(500_000n);
+  });
+
+  it("calculates v0.6 fee deposit locally on Studio when feeValue is omitted", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        validUntil: 123n,
+        fees: {
+          distribution: {
+            leaderTimeunitsAllocation: 100n,
+            validatorTimeunitsAllocation: 200n,
+            maxPriceGenPerTimeUnit: 10n,
+          },
+        },
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(estimateTransactionGas.mock.calls[0][0].value).toBe(11_000n);
+  });
+
+  it("estimates fee distribution caps and fee value from FeeManager prices", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+        if (functionName === "GENPerTimeUnit") return 10n;
+        if (functionName === "storageUnitPrice") return 20n;
+        if (functionName === "quoteGasPrice") return 30n;
+        if (functionName === "messageFeeParamsBudgetFloor") return 1_234n;
+        if (functionName === "calculateRoundFees") return 77n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+    };
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    const fees = await actions.estimateTransactionFees({totalMessageFees: 5n});
+
+    expect(fees.policy).toEqual({
+      enabled: true,
+      genPerTimeUnit: 10n,
+      storageUnitPrice: 20n,
+      receiptGasPrice: 30n,
+      executionBudgetFloor: 1_234n,
+    });
+    expect(fees.distribution.maxPriceGenPerTimeUnit).toBe(12n);
+    expect(fees.distribution.storageFeeMaxGasPrice).toBe(24n);
+    expect(fees.distribution.receiptFeeMaxGasPrice).toBe(36n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(500_000n);
+    expect(fees.feeValue).toBe(82n);
+  });
+
+  it("defaults total message fees from root and external message allocation budgets", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+        if (functionName === "GENPerTimeUnit") return 10n;
+        if (functionName === "storageUnitPrice") return 20n;
+        if (functionName === "quoteGasPrice") return 30n;
+        if (functionName === "messageFeeParamsBudgetFloor") return 1_234n;
+        if (functionName === "calculateRoundFees") return 77n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+    };
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    const fees = await actions.estimateTransactionFees({
+      messageAllocations: [
+        {
+          messageType: MessageType.Internal,
+          recipient: RECIPIENT_ADDRESS,
+          budget: 50n,
+          feeParams: "0x1234",
+        },
+        {
+          messageType: MessageType.Internal,
+          parentIndex: 0n,
+          recipient: RECIPIENT_ADDRESS,
+          budget: 10n,
+          feeParams: "0x1234",
+        },
+        {
+          messageType: MessageType.External,
+          recipient: RECIPIENT_ADDRESS,
+          budget: 30n,
+          feeParams: "0x1234",
+        },
+      ],
+    });
+
+    expect(fees.distribution.totalMessageFees).toBe(80n);
+    expect(fees.feeValue).toBe(157n);
+  });
+
+  it("estimates Studio fee value from sim_getFeeConfig when no FeeManager contract exists", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFees({priceCapHeadroomBps: 10_000n});
+
+    expect(fees.distribution.maxPriceGenPerTimeUnit).toBe(10n);
+    expect(fees.distribution.storageFeeMaxGasPrice).toBe(20n);
+    expect(fees.distribution.receiptFeeMaxGasPrice).toBe(30n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(9_185_760n);
+    expect(fees.feeValue).toBe(9_196_760n);
+  });
+
+  it("prefers Studio's exposed message fee budget floor over local fallback math", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+            fixedProposeReceiptGas: "1",
+            messageFeeParamsBudgetFloor: "700000",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFees({priceCapHeadroomBps: 10_000n});
+
+    expect(fees.policy.executionBudgetFloor).toBe(700_000n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(700_000n);
+    expect(fees.feeValue).toBe(711_000n);
+  });
+
+  it("builds a Studio trusted fee preset from a simulation fee report", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+            messageFeeParamsBudgetFloor: "400000",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFeesFromSimulation({
+      simulation: {
+        feeAccounting: {
+          execution_fee_consumed: "100",
+          genvm_message_fee_consumed: "5",
+          message_fee_budget: "10",
+          message_fee_consumed: "5",
+          message_fee_refunded: "0",
+          external_message_fee_reserved: "0",
+          external_message_fee_reimbursed: "0",
+          external_message_fee_remainder: "0",
+          execution_fee_report: {
+            receiptGasPrice: "30",
+            proposalReceipt: {
+              eqBlocksOutputsLength: "10",
+              receiptBytes: "1034",
+              estimatedGas: "314544",
+              fee: "314544",
+            },
+            messageReveal: {
+              messageBytes: "320",
+              messageCount: "1",
+              estimatedGas: "187120",
+              fee: "187120",
+              consensusAdditionalGas: "87120",
+              consensusAdditionalFee: "87120",
+              studioFixedOverheadGas: "100000",
+              studioFixedOverheadFee: "100000",
+              messages: [
+                {
+                  messageFeeMode: "mode1",
+                  messageType: "Internal",
+                  recipient: RECIPIENT_ADDRESS,
+                  value: "0",
+                  dataBytes: "2",
+                  onAcceptance: true,
+                  saltNonce: "0",
+                  feeParams: "0x1234",
+                  feeParamsDecoded: null,
+                  feeParamsBytes: "2",
+                  declaredBudget: "5",
+                  allocationSubtree: "0x",
+                  allocationSubtreeBytes: "0",
+                  callKey: `0x${"12".repeat(32)}`,
+                },
+              ],
+            },
+            chargeableExecution: {
+              receiptAndNondetOutput: "501664",
+              storage: "0",
+              message: "0",
+              totalExecution: "501664",
+              totalWithMessage: "501664",
+              executionBudgetPerRound: "600000",
+              executionBudgetRemaining: "98336",
+              executionBudgetOverrun: "0",
+              executionBudgetExceeded: false,
+            },
+            genvmBuckets: {
+              receiptAndNondetOutput: "100",
+              storage: "0",
+              message: "5",
+              totalExecution: "100",
+              totalWithMessage: "105",
+              executionBudgetPerRound: "600000",
+              executionBudgetRemaining: "599900",
+              executionBudgetOverrun: "0",
+              executionBudgetExceeded: false,
+              buckets: [
+                {index: "0", name: "receiptAndNondetOutput", consumed: "100"},
+                {index: "1", name: "storage", consumed: "0"},
+                {index: "2", name: "message", consumed: "5"},
+              ],
+            },
+            executionMetering: {
+              chargeableExecutionFee: "501664",
+              genvmReportedExecution: "100",
+              genvmDeltaFromChargeable: "-501564",
+            },
+            messageFees: {
+              budget: "10",
+              declaredConsumed: "5",
+              genvmMeteredConsumed: "5",
+              declaredRefunded: "0",
+              remaining: "5",
+              meteringDelta: "0",
+              reportedTotal: "5",
+            },
+            totalEstimatedFee: "501664",
+            totalStudioMeteredFee: "688784",
+          },
+        },
+      },
+      priceCapHeadroomBps: 10_000n,
+    });
+
+    expect(fees.observed).toEqual({
+      executionFeeConsumed: 100n,
+      executionFeeReportTotal: 501_664n,
+      recommendedExecutionBudgetPerRound: 602_117n,
+      genvmMessageFeeConsumed: 5n,
+      messageFeeBudget: 10n,
+      messageFeeConsumed: 5n,
+      messageFeeRefunded: 0n,
+      internalDeclaredBudget: 5n,
+      externalMessageReserved: 0n,
+      externalMessageReimbursed: 0n,
+      externalMessageRemainder: 0n,
+      recommendedTotalMessageFees: 6n,
+    });
+    expect(fees.distribution.executionBudgetPerRound).toBe(602_117n);
+    expect(fees.distribution.totalMessageFees).toBe(6n);
+    expect(fees.feeValue).toBe(613_123n);
+  });
+
+  it("builds a Studio trusted fee preset for a target write in one call", async () => {
+    const feeParams = encodeInternalMessageFeeParams({
+      leaderTimeunitsAllocation: 5n,
+      validatorTimeunitsAllocation: 10n,
+    });
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+            messageFeeParamsBudgetFloor: "400000",
+          },
+        };
+      }
+      if (method === "sim_estimateTransactionFees") {
+        return {
+          feeAccounting: {
+            execution_fee_consumed: "100",
+            message_fee_consumed: "50",
+            message_fee_budget: "110",
+            message_allocations: [
+              {
+                messageType: MessageType.Internal,
+                onAcceptance: true,
+                parentIndex: ((1n << 256n) - 1n).toString(),
+                recipient: RECIPIENT_ADDRESS,
+                callKey: `0x${"00".repeat(32)}`,
+                budget: "110",
+                feeParams,
+              },
+            ],
+            execution_fee_report: {
+              totalEstimatedFee: "501664",
+            },
+          },
+          feeReport: {
+            totalEstimatedFee: "501664",
+          },
+          recommendedPreset: {
+            distribution: {
+              leaderTimeunitsAllocation: "100",
+              validatorTimeunitsAllocation: "200",
+              appealRounds: "0",
+              executionBudgetPerRound: "700000",
+              executionConsumed: "0",
+              totalMessageFees: "110",
+              rotations: ["0"],
+              maxPriceGenPerTimeUnit: "10",
+              storageFeeMaxGasPrice: "20",
+              receiptFeeMaxGasPrice: "30",
+            },
+            messageAllocations: [
+              {
+                messageType: MessageType.Internal,
+                onAcceptance: true,
+                parentIndex: ((1n << 256n) - 1n).toString(),
+                recipient: RECIPIENT_ADDRESS,
+                callKey: `0x${"00".repeat(32)}`,
+                budget: "110",
+                feeParams,
+              },
+            ],
+            feeValue: "711110",
+          },
+        };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFeesForWrite({
+      address: RECIPIENT_ADDRESS,
+      functionName: "update_storage",
+      args: ["after"],
+      value: 7n,
+      priceCapHeadroomBps: 10_000n,
+      messageAllocations: [
+        {
+          messageType: MessageType.Internal,
+          recipient: RECIPIENT_ADDRESS,
+          budget: 110n,
+          feeParams,
+        },
+      ],
+    });
+
+    const simCall = requestMock.mock.calls.find(([call]) => call.method === "sim_estimateTransactionFees")?.[0];
+    expect(simCall).toBeDefined();
+    expect(simCall.params[0].value).toBe("0x7");
+    expect(simCall.params[0].fees.feeValue).toBe("511110");
+    expect(simCall.params[0].fees.distribution.totalMessageFees).toBe("110");
+    expect(simCall.params[0].fees.messageAllocations[0].budget).toBe("110");
+    expect(fees.observed?.recommendedExecutionBudgetPerRound).toBe(602_117n);
+    expect(fees.observed?.messageFeeBudget).toBe(110n);
+    expect(fees.observed?.messageFeeConsumed).toBe(50n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(700_000n);
+    expect(fees.distribution.totalMessageFees).toBe(110n);
+    expect(fees.messageAllocations?.[0].budget).toBe(110n);
+    expect(fees.feeValue).toBe(711_110n);
+  });
+
+  it("preserves mode-2 message allocations from simulation fee accounting", async () => {
+    const feeParams = encodeInternalMessageFeeParams({
+      leaderTimeunitsAllocation: 5n,
+      validatorTimeunitsAllocation: 10n,
+    });
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+            messageFeeParamsBudgetFloor: "400000",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFeesFromSimulation({
+      simulation: {
+        feeAccounting: {
+          message_fee_consumed: "20",
+          message_allocations: [
+            {
+              messageType: MessageType.Internal,
+              onAcceptance: false,
+              parentIndex: ((1n << 256n) - 1n).toString(),
+              recipient: RECIPIENT_ADDRESS,
+              callKey: `0x${"00".repeat(32)}`,
+              budget: "50",
+              feeParams,
+            },
+          ],
+        },
+      },
+      priceCapHeadroomBps: 10_000n,
+    });
+
+    expect(fees.messageAllocations).toHaveLength(1);
+    expect(fees.messageAllocations?.[0].budget).toBe(50n);
+    expect(fees.messageAllocations?.[0].feeParams).toBe(feeParams);
+    expect(fees.distribution.totalMessageFees).toBe(50n);
+    expect(fees.feeValue).toBe(511_050n);
+  });
+
+  it("keeps Studio fee estimation gasless when sim_getFeeConfig is disabled", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: false,
+          policy: {
+            genPerTimeUnit: "0",
+            storageUnitPrice: "0",
+            receiptGasPrice: "0",
+          },
+        };
+      }
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFees();
+
+    expect(fees.policy.enabled).toBe(false);
+    expect(fees.distribution.leaderTimeunitsAllocation).toBe(0n);
+    expect(fees.distribution.validatorTimeunitsAllocation).toBe(0n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(0n);
+    expect(fees.distribution.maxPriceGenPerTimeUnit).toBe(0n);
+    expect(fees.distribution.storageFeeMaxGasPrice).toBe(0n);
+    expect(fees.distribution.receiptFeeMaxGasPrice).toBe(0n);
+    expect(fees.feeValue).toBe(0n);
   });
 
   it("retries with v6 signature when v5 signature fails with ABI mismatch", async () => {
@@ -307,7 +1296,7 @@ describe("contractActions addTransaction ABI compatibility", () => {
       from: SENDER_ADDRESS,
       to: MAIN_CONTRACT_ADDRESS,
       value: "0x0",
-      gas: "0x5208",
+      gas: "0xa410",
       nonce: "0x0",
       type: "0x0",
       chainId: "0xeec7",
@@ -471,6 +1460,29 @@ const FINALIZE_TX_ABI = [
   },
 ];
 
+const FEE_MANAGEMENT_ABI = [
+  {
+    type: "function" as const,
+    name: "topUpFees",
+    stateMutability: "payable" as const,
+    inputs: [
+      {name: "_txId", type: "bytes32"},
+      {name: "_feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+    ],
+    outputs: [],
+  },
+  {
+    type: "function" as const,
+    name: "topUpAndSubmitAppeal",
+    stateMutability: "payable" as const,
+    inputs: [
+      {name: "_txId", type: "bytes32"},
+      {name: "_feesDistribution", type: "tuple", components: FEES_DISTRIBUTION_COMPONENTS},
+    ],
+    outputs: [],
+  },
+] as const;
+
 const finalizeTransactionSelector = encodeFunctionData({
   abi: FINALIZE_TX_ABI as any,
   functionName: "finalizeTransaction",
@@ -481,6 +1493,46 @@ const finalizeIdlenessSelector = encodeFunctionData({
   abi: FINALIZE_TX_ABI as any,
   functionName: "finalizeIdlenessTxs",
   args: [[MOCK_GENLAYER_TX_ID]],
+}).slice(0, 10);
+
+const topUpFeesSelector = encodeFunctionData({
+  abi: FEE_MANAGEMENT_ABI as any,
+  functionName: "topUpFees",
+  args: [
+    MOCK_GENLAYER_TX_ID,
+    {
+      leaderTimeunitsAllocation: 0n,
+      validatorTimeunitsAllocation: 0n,
+      appealRounds: 0n,
+      executionBudgetPerRound: 0n,
+      executionConsumed: 0n,
+      totalMessageFees: 0n,
+      rotations: [0n],
+      maxPriceGenPerTimeUnit: 0n,
+      storageFeeMaxGasPrice: 0n,
+      receiptFeeMaxGasPrice: 0n,
+    },
+  ],
+}).slice(0, 10);
+
+const topUpAndSubmitAppealSelector = encodeFunctionData({
+  abi: FEE_MANAGEMENT_ABI as any,
+  functionName: "topUpAndSubmitAppeal",
+  args: [
+    MOCK_GENLAYER_TX_ID,
+    {
+      leaderTimeunitsAllocation: 0n,
+      validatorTimeunitsAllocation: 0n,
+      appealRounds: 0n,
+      executionBudgetPerRound: 0n,
+      executionConsumed: 0n,
+      totalMessageFees: 0n,
+      rotations: [0n],
+      maxPriceGenPerTimeUnit: 0n,
+      storageFeeMaxGasPrice: 0n,
+      receiptFeeMaxGasPrice: 0n,
+    },
+  ],
 }).slice(0, 10);
 
 const setupFinalizeHarness = ({receiptStatus = "success"}: {receiptStatus?: string} = {}) => {
@@ -495,6 +1547,48 @@ const setupFinalizeHarness = ({receiptStatus = "success"}: {receiptStatus?: stri
       consensusMainContract: {
         address: MAIN_CONTRACT_ADDRESS,
         abi: FINALIZE_TX_ABI,
+        bytecode: "0x",
+      },
+    },
+    account: {
+      address: SENDER_ADDRESS,
+      type: "local",
+      signTransaction,
+    },
+    getCurrentNonce: vi.fn().mockResolvedValue(0n),
+    estimateTransactionGas,
+    sendRawTransaction,
+    request: vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "eth_gasPrice") return "0x1";
+      throw new Error(`Unexpected RPC method: ${method}`);
+    }),
+  };
+
+  const publicClient = {waitForTransactionReceipt};
+  const actions = contractActions(client as any, publicClient as any);
+
+  return {actions, signTransaction, sendRawTransaction, waitForTransactionReceipt, estimateTransactionGas, client};
+};
+
+const setupFeeManagementHarness = ({
+  receiptStatus = "success",
+  isStudio = false,
+}: {
+  receiptStatus?: string;
+  isStudio?: boolean;
+} = {}) => {
+  const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+  const sendRawTransaction = vi.fn().mockResolvedValue(MOCK_EVM_TX_HASH);
+  const waitForTransactionReceipt = vi.fn().mockResolvedValue({status: receiptStatus, logs: []});
+  const estimateTransactionGas = vi.fn().mockResolvedValue(21_000n);
+
+  const client = {
+    chain: {
+      id: 61_127,
+      isStudio,
+      consensusMainContract: {
+        address: MAIN_CONTRACT_ADDRESS,
+        abi: FEE_MANAGEMENT_ABI,
         bytecode: "0x",
       },
     },
@@ -645,6 +1739,145 @@ describe("contractActions getContractSchemaForCode", () => {
       method: "gen_getContractSchema",
       params: [{code: SOURCE_B64}],
     });
+  });
+});
+
+describe("contractActions fee management", () => {
+  it("encodes topUpFees(bytes32, FeesDistribution) and returns the EVM tx hash", async () => {
+    const {actions, signTransaction, sendRawTransaction} = setupFeeManagementHarness();
+
+    const evmHash = await actions.topUpFees({
+      txId: MOCK_GENLAYER_TX_ID,
+      value: 999n,
+      distribution: {
+        leaderTimeunitsAllocation: 100n,
+        validatorTimeunitsAllocation: 200n,
+        appealRounds: 1n,
+        executionBudgetPerRound: 500_000n,
+        totalMessageFees: 30n,
+        rotations: [0n, 2n],
+        maxPriceGenPerTimeUnit: 12n,
+        storageFeeMaxGasPrice: 24n,
+        receiptFeeMaxGasPrice: 36n,
+      },
+    });
+
+    expect(evmHash).toBe(MOCK_EVM_TX_HASH);
+    expect(sendRawTransaction).toHaveBeenCalledWith({serializedTransaction: "0xsigned"});
+    const txRequest = signTransaction.mock.calls[0][0];
+    expect(txRequest.to).toBe(MAIN_CONTRACT_ADDRESS);
+    expect(txRequest.value).toBe(999n);
+    expect(txRequest.data.slice(0, 10)).toBe(topUpFeesSelector);
+
+    const decoded = decodeFunctionData({
+      abi: FEE_MANAGEMENT_ABI as any,
+      data: txRequest.data,
+    });
+    const [txId, distribution] = decoded.args as any[];
+    expect(txId).toBe(MOCK_GENLAYER_TX_ID);
+    expect(distribution.leaderTimeunitsAllocation).toBe(100n);
+    expect(distribution.validatorTimeunitsAllocation).toBe(200n);
+    expect(distribution.appealRounds).toBe(1n);
+    expect(distribution.executionBudgetPerRound).toBe(500_000n);
+    expect(distribution.totalMessageFees).toBe(30n);
+    expect(distribution.rotations).toEqual([0n, 2n]);
+    expect(distribution.maxPriceGenPerTimeUnit).toBe(12n);
+    expect(distribution.storageFeeMaxGasPrice).toBe(24n);
+    expect(distribution.receiptFeeMaxGasPrice).toBe(36n);
+  });
+
+  it("encodes topUpAndSubmitAppeal(bytes32, FeesDistribution) and returns the GenLayer tx id", async () => {
+    const {actions, signTransaction, sendRawTransaction} = setupFeeManagementHarness();
+
+    const txId = await actions.topUpAndSubmitAppeal({
+      txId: MOCK_GENLAYER_TX_ID,
+      value: 1234n,
+      distribution: {
+        appealRounds: 1n,
+        rotations: [0n, 1n],
+      },
+    });
+
+    expect(txId).toBe(MOCK_GENLAYER_TX_ID);
+    expect(sendRawTransaction).toHaveBeenCalledWith({serializedTransaction: "0xsigned"});
+    const txRequest = signTransaction.mock.calls[0][0];
+    expect(txRequest.to).toBe(MAIN_CONTRACT_ADDRESS);
+    expect(txRequest.value).toBe(1234n);
+    expect(txRequest.data.slice(0, 10)).toBe(topUpAndSubmitAppealSelector);
+
+    const decoded = decodeFunctionData({
+      abi: FEE_MANAGEMENT_ABI as any,
+      data: txRequest.data,
+    });
+    const [decodedTxId, distribution] = decoded.args as any[];
+    expect(decodedTxId).toBe(MOCK_GENLAYER_TX_ID);
+    expect(distribution.appealRounds).toBe(1n);
+    expect(distribution.rotations).toEqual([0n, 1n]);
+  });
+
+  it("throws when a fee management consensus call is reverted", async () => {
+    const {actions} = setupFeeManagementHarness({receiptStatus: "reverted"});
+
+    await expect(
+      actions.topUpFees({
+        txId: MOCK_GENLAYER_TX_ID,
+        value: 1n,
+        distribution: {},
+      }),
+    ).rejects.toThrow(/Top up fees reverted/);
+  });
+
+  it("returns the Studio RPC hash for fee management calls without waiting for an EVM receipt", async () => {
+    const {actions, waitForTransactionReceipt} = setupFeeManagementHarness({isStudio: true});
+
+    const hash = await actions.topUpFees({
+      txId: MOCK_GENLAYER_TX_ID,
+      value: 1n,
+      distribution: {},
+    });
+
+    expect(hash).toBe(MOCK_EVM_TX_HASH);
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it("returns the Studio RPC hash for external-wallet fee management calls without waiting for an EVM receipt", async () => {
+    const request = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "eth_gasPrice") return "0x1";
+      if (method === "eth_sendTransaction") return MOCK_EVM_TX_HASH;
+      throw new Error(`Unexpected RPC method: ${method}`);
+    });
+    const waitForTransactionReceipt = vi.fn();
+    const client = {
+      chain: {
+        id: 61_127,
+        isStudio: true,
+        consensusMainContract: {
+          address: MAIN_CONTRACT_ADDRESS,
+          abi: FEE_MANAGEMENT_ABI,
+          bytecode: "0x",
+        },
+      },
+      account: {
+        address: SENDER_ADDRESS,
+        type: "json-rpc",
+      },
+      getCurrentNonce: vi.fn().mockResolvedValue(0n),
+      estimateTransactionGas: vi.fn().mockResolvedValue(21_000n),
+      request,
+    };
+    const actions = contractActions(client as any, {waitForTransactionReceipt} as any);
+
+    const hash = await actions.topUpFees({
+      txId: MOCK_GENLAYER_TX_ID,
+      value: 1n,
+      distribution: {},
+    });
+
+    expect(hash).toBe(MOCK_EVM_TX_HASH);
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      method: "eth_sendTransaction",
+    }));
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Adds fee-aware transaction builders, fee/message allocation helpers, and tests for the M5/v0.6 tooling train. Validated locally with npm test -- --run and npm run build.