### PR TITLE
feat(fees)!: estimation correctness, wait-for-decided semantics, v0.6 enum completeness

### DIFF
--- a/.github/workflows/chains-drift.yml
+++ b/.github/workflows/chains-drift.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - v1
+      - v2-dev
+      - v2
   push:
     branches:
       - v1
+      - v2-dev
+      - v2
   schedule:
     # Daily at 07:00 UTC. Catches upstream contract deployments even when no
     # PRs are open against the SDK.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - v1
+      - v2-dev
+      - v2
   pull_request:
     branches:
       - v1
+      - v2-dev
+      - v2
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsup src/index.ts src/chains/index.ts src/types/index.ts --format cjs,esm --dts --splitting --out-dir dist --no-treeshake",
     "build:watch": "tsup src/index.ts src/chains/index.ts src/types/index.ts --format cjs,esm --dts --splitting --out-dir dist --no-treeshake --watch",
     "test": "vitest --typecheck",

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1017,7 +1017,9 @@ const DEFAULT_PRICE_CAP_HEADROOM_BPS = 12_000n;
 const DEFAULT_LEADER_TIMEUNITS_ALLOCATION = 100n;
 const DEFAULT_VALIDATOR_TIMEUNITS_ALLOCATION = 200n;
 const DEFAULT_TRANSACTION_EXECUTION_BUDGET_PER_ROUND = 500_000n;
-const DEFAULT_TRANSACTION_EXECUTION_GAS = 100_000_000n;
+// Provisional heuristic sized ~20x observed dev-env consumption (~5M gas-equivalent).
+// TODO(data): replace with telemetry-derived default (p99 x margin) once fee consumption telemetry is collected.
+export const DEFAULT_TRANSACTION_EXECUTION_GAS = 100_000_000n;
 const DEFAULT_RECEIPT_SLOTS_CHANGED = 7n;
 const DEFAULT_INTRINSIC_GAS = 21_000n;
 const DEFAULT_BOOTLOADER_OVERHEAD = 60_000n;
@@ -1025,6 +1027,8 @@ const DEFAULT_GAS_PER_CHANGED_SLOT = 1_000n;
 const DEFAULT_CALLDATA_GAS_PER_BYTE = 16n;
 const DEFAULT_FIXED_PROPOSE_RECEIPT_GAS = 210_000n;
 const DEFAULT_FIXED_MESSAGE_REVEAL_GAS = 100_000n;
+// ConsensusHelpers.MIN_RECEIPT_BYTES — smallest receipt payload the on-chain budget floor prices.
+const DEFAULT_MIN_RECEIPT_BYTES = 512n;
 const DEFAULT_MESSAGE_REVEAL_LENGTH_SLOTS = 32n;
 const DEFAULT_NONDET_OUTPUT_LENGTH_BYTES = 32n;
 const TRANSACTION_GAS_HEADROOM_BPS = 20_000n;
@@ -1158,19 +1162,38 @@ const readCurrentFeePolicy = async (
 
   const address = client.chain.feeManagerContract.address as `0x${string}`;
   const abi = FEE_MANAGER_CALCULATE_ROUND_FEES_ABI as any;
-  const [genPerTimeUnit, storageUnitPrice, receiptGasPrice, executionBudgetFloor] = await Promise.all([
+  const [genPerTimeUnit, storageUnitPrice, quotedReceiptGasPrice, executionBudgetFloor] = await Promise.all([
     publicClient.readContract({address, abi, functionName: "GENPerTimeUnit", args: []}) as Promise<bigint>,
     publicClient.readContract({address, abi, functionName: "storageUnitPrice", args: []}) as Promise<bigint>,
     publicClient.readContract({address, abi, functionName: "quoteGasPrice", args: []}) as Promise<bigint>,
     publicClient.readContract({address, abi, functionName: "messageFeeParamsBudgetFloor", args: []}) as Promise<bigint>,
   ]);
+  const enabled = genPerTimeUnit > 0n || storageUnitPrice > 0n || quotedReceiptGasPrice > 0n;
+  const networkReceiptGasPrice = enabled ? await publicClient.getGasPrice() : 0n;
+  const receiptGasPrice = maxBigint(quotedReceiptGasPrice, networkReceiptGasPrice);
+  if (enabled && receiptGasPrice === 0n) {
+    throw new Error("receipt gas price quoted as zero; refusing to build a zero price cap");
+  }
+
+  // messageFeeParamsBudgetFloor() multiplies by quoteGasPrice() on-chain, which reads
+  // tx.gasprice ~ 0 under a plain eth_call — so the view can report a zero floor on
+  // chain-derived networks while the real submission-time floor is non-zero. Recompute
+  // the floor locally at the effective receipt price (FeeManager.estimateProposeReceiptGas
+  // at ConsensusHelpers.MIN_RECEIPT_BYTES) and take the max.
+  const localExecutionBudgetFloor = receiptGasPrice * (
+    DEFAULT_FIXED_PROPOSE_RECEIPT_GAS +
+    DEFAULT_INTRINSIC_GAS +
+    DEFAULT_BOOTLOADER_OVERHEAD +
+    (DEFAULT_MIN_RECEIPT_BYTES * DEFAULT_CALLDATA_GAS_PER_BYTE) +
+    (DEFAULT_RECEIPT_SLOTS_CHANGED * DEFAULT_GAS_PER_CHANGED_SLOT)
+  );
 
   return {
-    enabled: genPerTimeUnit > 0n || storageUnitPrice > 0n || receiptGasPrice > 0n,
+    enabled,
     genPerTimeUnit,
     storageUnitPrice,
     receiptGasPrice,
-    executionBudgetFloor,
+    executionBudgetFloor: maxBigint(executionBudgetFloor, localExecutionBudgetFloor),
   };
 };
 
@@ -1330,7 +1353,7 @@ const observedSimulationFeeUsage = (
   const observedExecutionBudget = executionFeeConsumed + executionFeeReportTotal;
   const recommendedExecutionBudgetPerRound = observedExecutionBudget > 0n
     ? maxBigint(
-        defaultExecutionBudgetPerRound(policy),
+        policy.executionBudgetFloor,
         withCapHeadroom(observedExecutionBudget, executionHeadroomBps),
       )
     : 0n;
@@ -1985,6 +2008,9 @@ const _sendTransaction = async ({
     "0x8d53e553": "InsufficientFees",
     "0xb4132db3": "MaxPriceExceeded",
     "0x57df8523": "ExecutionBudgetExceeded",
+    "0x305e533c": "BudgetTooLow",
+    "0xa70732ee": "RollupBudgetBelowFloor",
+    "0x632be5a1": "FeeValueMustBeNonZero",
   };
 
   const stringifyRpcError = (error: unknown): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export {
 export * as chains from "./chains";
 export * as abi from "./abi";
 export * from "./transactions/fees";
+export {isSuccessful} from "./transactions/actions";
 export {parseStakingAmount, formatStakingAmount} from "./staking";
 export {buildGenVmPositionalArgs} from "./contracts/schema";

--- a/src/transactions/ITransactionActions.ts
+++ b/src/transactions/ITransactionActions.ts
@@ -1,15 +1,20 @@
-import {TransactionHash, TransactionStatus, GenLayerTransaction} from "@/types";
+import {TransactionHash, TransactionStatus, GenLayerTransaction, TransactionReceiptWaitUntil} from "@/types";
 
 export type ITransactionActions = {
   waitForTransactionReceipt: ({
     hash,
     status,
+    waitUntil,
     interval,
     retries,
+    fullTransaction,
   }: {
     hash: TransactionHash;
-    status: TransactionStatus;
+    /** @deprecated Use waitUntil: "decided" or waitUntil: "finalized" instead. */
+    status?: TransactionStatus;
+    waitUntil?: TransactionReceiptWaitUntil;
     interval?: number;
     retries?: number;
+    fullTransaction?: boolean;
   }) => Promise<GenLayerTransaction>;
 };

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -4,9 +4,13 @@ import {
   TransactionStatus,
   GenLayerTransaction,
   GenLayerRawTransaction,
+  ExecutionResult,
   transactionsStatusNameToNumber,
+  transactionsStatusNumberToName,
+  executionResultNumberToName,
   isDecidedState,
   DebugTraceResult,
+  TransactionReceiptWaitUntil,
 } from "../types/transactions";
 import {transactionsConfig} from "../config/transactions";
 import {sleep} from "../utils/async";
@@ -14,21 +18,92 @@ import {GenLayerChain} from "@/types";
 import {Abi, PublicClient, Address, keccak256, concat, stringToBytes, toBytes} from "viem";
 import {decodeLocalnetTransaction, decodeTransaction, simplifyTransactionReceipt} from "./decoders";
 
+let didWarnWaitForTransactionReceiptStatus = false;
+
+const warnDeprecatedReceiptStatus = () => {
+  if (didWarnWaitForTransactionReceiptStatus) return;
+  didWarnWaitForTransactionReceiptStatus = true;
+  console.warn("waitForTransactionReceipt({ status }) is deprecated; use waitUntil: 'decided' or waitUntil: 'finalized' instead.");
+};
+
+const resolveWaitTarget = (
+  status: TransactionStatus | undefined,
+  waitUntil: TransactionReceiptWaitUntil | undefined,
+): {
+  waitUntil?: TransactionReceiptWaitUntil;
+  legacyStatus?: TransactionStatus;
+  label: string;
+} => {
+  if (waitUntil) {
+    return {waitUntil, label: waitUntil};
+  }
+  if (!status) {
+    return {waitUntil: "decided", label: "decided"};
+  }
+
+  warnDeprecatedReceiptStatus();
+  if (status === TransactionStatus.ACCEPTED) {
+    return {waitUntil: "decided", label: "decided"};
+  }
+  if (status === TransactionStatus.FINALIZED) {
+    return {waitUntil: "finalized", label: "finalized"};
+  }
+  return {legacyStatus: status, label: status};
+};
+
+const hasReachedWaitTarget = (
+  transactionStatusString: string,
+  target: ReturnType<typeof resolveWaitTarget>,
+): boolean => {
+  if (target.waitUntil === "decided") {
+    return isDecidedState(transactionStatusString);
+  }
+  if (target.waitUntil === "finalized") {
+    return transactionStatusString === transactionsStatusNameToNumber[TransactionStatus.FINALIZED];
+  }
+  if (!target.legacyStatus) return false;
+  return transactionStatusString === transactionsStatusNameToNumber[target.legacyStatus];
+};
+
+export const isSuccessful = (transaction: GenLayerTransaction): boolean => {
+  const statusName = transaction.statusName ?? (
+    typeof transaction.status === "string" && transaction.status in TransactionStatus
+      ? transaction.status as TransactionStatus
+      : transaction.status === undefined
+        ? undefined
+        : transactionsStatusNumberToName[String(transaction.status) as keyof typeof transactionsStatusNumberToName]
+  );
+  const executionResultName = transaction.txExecutionResultName ?? (
+    transaction.txExecutionResult === undefined
+      ? undefined
+      : executionResultNumberToName[String(transaction.txExecutionResult) as keyof typeof executionResultNumberToName]
+  );
+
+  return (
+    (statusName === TransactionStatus.ACCEPTED || statusName === TransactionStatus.FINALIZED) &&
+    executionResultName === ExecutionResult.FINISHED_WITH_RETURN
+  );
+};
+
 export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) => ({
   /** Polls until a transaction reaches the specified status. Returns the transaction receipt. */
   waitForTransactionReceipt: async ({
     hash,
-    status = TransactionStatus.ACCEPTED,
+    status,
+    waitUntil,
     interval = transactionsConfig.waitInterval,
     retries = transactionsConfig.retries,
     fullTransaction = false,
   }: {
     hash: TransactionHash;
-    status: TransactionStatus;
+    /** @deprecated Use waitUntil: "decided" or waitUntil: "finalized" instead. */
+    status?: TransactionStatus;
+    waitUntil?: TransactionReceiptWaitUntil;
     interval?: number;
     retries?: number;
     fullTransaction?: boolean;
   }): Promise<GenLayerTransaction> => {
+    const target = resolveWaitTarget(status, waitUntil);
     const transaction = await client.getTransaction({
       hash,
     });
@@ -37,11 +112,7 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
       throw new Error(`Transaction not found: ${hash}`);
     }
     const transactionStatusString = String(transaction.status);
-    const requestedStatus = transactionsStatusNameToNumber[status];
-    if (
-      transactionStatusString === requestedStatus ||
-      (status === TransactionStatus.ACCEPTED && isDecidedState(transactionStatusString))
-    ) {
+    if (hasReachedWaitTarget(transactionStatusString, target)) {
       let finalTransaction = transaction;
       if (client.chain.isStudio) {
         finalTransaction = decodeLocalnetTransaction(transaction as unknown as GenLayerTransaction);
@@ -53,13 +124,14 @@ export const receiptActions = (client: GenLayerClient<GenLayerChain>, publicClie
     }
 
     if (retries === 0) {
-      throw new Error(`Timed out waiting for transaction ${hash} to reach status "${status}" (current status: ${transactionStatusString}).`);
+      throw new Error(`Timed out waiting for transaction ${hash} to reach "${target.label}" (current status: ${transactionStatusString}).`);
     }
 
     await sleep(interval);
     return receiptActions(client, publicClient).waitForTransactionReceipt({
       hash,
-      status,
+      waitUntil: target.waitUntil,
+      status: target.legacyStatus,
       interval,
       retries: retries - 1,
       fullTransaction,

--- a/src/transactions/fees.ts
+++ b/src/transactions/fees.ts
@@ -15,7 +15,10 @@ import {
 export const MESSAGE_ALLOCATION_ROOT_PARENT_INDEX = (1n << 256n) - 1n;
 export const CALL_KEY_WILDCARD = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
 export const CALL_KEY_UNNAMED = CALL_KEY_WILDCARD;
-export const CALL_KEY_DEPLOY = CALL_KEY_WILDCARD;
+export const DEPLOY_CALL_KEY = "0x0000000000000000000000000000000000000000000000000000000000000001" as const;
+export const CALL_KEY_DEPLOY = DEPLOY_CALL_KEY;
+
+export const deployCallKey = (): Hex => DEPLOY_CALL_KEY;
 
 const bytesToPaddedCallKey = (bytes: Uint8Array): Hex => {
   if (bytes.length > 32) {

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -3,6 +3,7 @@ import {
   GenLayerTransaction,
   TransactionHash,
   TransactionStatus,
+  TransactionReceiptWaitUntil,
   TransactionHashVariant,
   DebugTraceResult,
   TransactionFeeOptions,
@@ -120,7 +121,9 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
     }) => Promise<bigint>;
     waitForTransactionReceipt: (args: {
       hash: TransactionHash;
+      /** @deprecated Use waitUntil: "decided" or waitUntil: "finalized" instead. */
       status?: TransactionStatus;
+      waitUntil?: TransactionReceiptWaitUntil;
       interval?: number;
       retries?: number;
       fullTransaction?: boolean;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -21,6 +21,7 @@ export enum TransactionStatus {
   READY_TO_FINALIZE = "READY_TO_FINALIZE",
   VALIDATORS_TIMEOUT = "VALIDATORS_TIMEOUT",
   LEADER_TIMEOUT = "LEADER_TIMEOUT",
+  LEADER_REVEALING = "LEADER_REVEALING",
 }
 
 export enum TransactionResult {
@@ -37,6 +38,7 @@ export enum TransactionResult {
   NO_MAJORITY = "NO_MAJORITY",
   MAJORITY_AGREE = "MAJORITY_AGREE",
   MAJORITY_DISAGREE = "MAJORITY_DISAGREE",
+  MAJORITY_TIMEOUT = "MAJORITY_TIMEOUT",
 }
 
 export const transactionsStatusNumberToName = {
@@ -54,6 +56,7 @@ export const transactionsStatusNumberToName = {
   "11": TransactionStatus.READY_TO_FINALIZE,
   "12": TransactionStatus.VALIDATORS_TIMEOUT,
   "13": TransactionStatus.LEADER_TIMEOUT,
+  "14": TransactionStatus.LEADER_REVEALING,
 };
 
 export const transactionsStatusNameToNumber = {
@@ -71,6 +74,7 @@ export const transactionsStatusNameToNumber = {
   [TransactionStatus.READY_TO_FINALIZE]: "11",
   [TransactionStatus.VALIDATORS_TIMEOUT]: "12",
   [TransactionStatus.LEADER_TIMEOUT]: "13",
+  [TransactionStatus.LEADER_REVEALING]: "14",
 };
 
 export const DECIDED_STATES = [
@@ -90,36 +94,36 @@ export function isDecidedState(status: string): boolean {
 
 export const transactionResultNumberToName = {
   "0": TransactionResult.IDLE,
-  "1": TransactionResult.AGREE,
-  "2": TransactionResult.DISAGREE,
-  "3": TransactionResult.TIMEOUT,
+  "1": TransactionResult.MAJORITY_AGREE,
+  "2": TransactionResult.MAJORITY_DISAGREE,
+  "3": TransactionResult.MAJORITY_TIMEOUT,
   "4": TransactionResult.DETERMINISTIC_VIOLATION,
   "5": TransactionResult.NO_MAJORITY,
-  "6": TransactionResult.MAJORITY_AGREE,
-  "7": TransactionResult.MAJORITY_DISAGREE,
 };
 
 export const TransactionResultNameToNumber = {
   [TransactionResult.IDLE]: "0",
-  [TransactionResult.AGREE]: "1",
-  [TransactionResult.DISAGREE]: "2",
-  [TransactionResult.TIMEOUT]: "3",
+  [TransactionResult.MAJORITY_AGREE]: "1",
+  [TransactionResult.MAJORITY_DISAGREE]: "2",
+  [TransactionResult.MAJORITY_TIMEOUT]: "3",
   [TransactionResult.DETERMINISTIC_VIOLATION]: "4",
   [TransactionResult.NO_MAJORITY]: "5",
-  [TransactionResult.MAJORITY_AGREE]: "6",
-  [TransactionResult.MAJORITY_DISAGREE]: "7",
 };
 
 export enum ExecutionResult {
   NOT_VOTED = "NOT_VOTED",
   FINISHED_WITH_RETURN = "FINISHED_WITH_RETURN",
   FINISHED_WITH_ERROR = "FINISHED_WITH_ERROR",
+  TIMEOUT = "TIMEOUT",
+  NONDET_DISAGREE = "NONDET_DISAGREE",
 }
 
 export const executionResultNumberToName = {
   "0": ExecutionResult.NOT_VOTED,
   "1": ExecutionResult.FINISHED_WITH_RETURN,
   "2": ExecutionResult.FINISHED_WITH_ERROR,
+  "3": ExecutionResult.TIMEOUT,
+  "4": ExecutionResult.NONDET_DISAGREE,
 };
 
 export enum VoteType {
@@ -152,6 +156,8 @@ export enum TransactionHashVariant {
   LATEST_FINAL = "latest-final",
   LATEST_NONFINAL = "latest-nonfinal",
 }
+
+export type TransactionReceiptWaitUntil = "decided" | "finalized";
 
 export enum MessageType {
   External = 0,

--- a/tests/client.test-d.ts
+++ b/tests/client.test-d.ts
@@ -44,6 +44,12 @@ test("type checks", () => {
 
   void client.waitForTransactionReceipt({
     hash: "0x1234567890123456789012345678901234567890123456789012345678901234" as TransactionHash,
+    waitUntil: "decided",
+    fullTransaction: true,
+  });
+
+  void client.waitForTransactionReceipt({
+    hash: "0x1234567890123456789012345678901234567890123456789012345678901234" as TransactionHash,
     status: TransactionStatus.FINALIZED,
   });
 

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -4,6 +4,8 @@ import {contractActions} from "../src/contracts/actions";
 import {
   CALL_KEY_DEPLOY,
   CALL_KEY_WILDCARD,
+  DEPLOY_CALL_KEY,
+  deployCallKey,
   deriveExternalMessageCallKey,
   deriveInternalMessageCallKey,
   encodeExternalMessageFeeParams,
@@ -433,7 +435,9 @@ describe("contractActions addTransaction ABI compatibility", () => {
     );
 
     expect(deriveInternalMessageCallKey()).toBe(CALL_KEY_WILDCARD);
-    expect(CALL_KEY_DEPLOY).toBe(CALL_KEY_WILDCARD);
+    expect(DEPLOY_CALL_KEY).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+    expect(CALL_KEY_DEPLOY).toBe(DEPLOY_CALL_KEY);
+    expect(deployCallKey()).toBe(DEPLOY_CALL_KEY);
     expect(deriveExternalMessageCallKey("0xaabbccdd11223344")).toBe(
       `0xaabbccdd${"0".repeat(56)}`,
     );
@@ -700,6 +704,7 @@ describe("contractActions addTransaction ABI compatibility", () => {
         if (functionName === "calculateRoundFees") return 77n;
         throw new Error(`unexpected readContract ${functionName}`);
       }),
+      getGasPrice: vi.fn().mockResolvedValue(1n),
     };
     const {actions} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
@@ -709,18 +714,96 @@ describe("contractActions addTransaction ABI compatibility", () => {
 
     const fees = await actions.estimateTransactionFees({totalMessageFees: 5n});
 
+    // Effective floor = max(on-chain view (1,234 — reads ~0-priced quoteGasPrice under
+    // eth_call), local recompute at the effective receipt price). Local formula pins
+    // FeeManager.estimateProposeReceiptGas(MIN_RECEIPT_BYTES=512):
+    // 210,000 + 21,000 + 60,000 + 512*16 + 7*1,000 = 306,192 gas.
+    const expectedLocalFloor = 30n * (210_000n + 21_000n + 60_000n + 512n * 16n + 7n * 1_000n);
+    expect(expectedLocalFloor).toBe(30n * 306_192n);
     expect(fees.policy).toEqual({
       enabled: true,
       genPerTimeUnit: 10n,
       storageUnitPrice: 20n,
       receiptGasPrice: 30n,
-      executionBudgetFloor: 1_234n,
+      executionBudgetFloor: expectedLocalFloor,
     });
     expect(fees.distribution.maxPriceGenPerTimeUnit).toBe(12n);
     expect(fees.distribution.storageFeeMaxGasPrice).toBe(24n);
     expect(fees.distribution.receiptFeeMaxGasPrice).toBe(36n);
     expect(fees.distribution.executionBudgetPerRound).toBe(3_000_300_000n);
     expect(fees.feeValue).toBe(82n);
+  });
+
+  it("uses the network gas price when FeeManager quotes a lower receipt gas price", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+        if (functionName === "GENPerTimeUnit") return 10n;
+        if (functionName === "storageUnitPrice") return 20n;
+        if (functionName === "quoteGasPrice") return 0n;
+        if (functionName === "messageFeeParamsBudgetFloor") return 1_234n;
+        if (functionName === "calculateRoundFees") return 77n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+      getGasPrice: vi.fn().mockResolvedValue(25n),
+    };
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    const fees = await actions.estimateTransactionFees({priceCapHeadroomBps: 10_000n});
+
+    expect(publicClient.getGasPrice).toHaveBeenCalledOnce();
+    expect(fees.policy.receiptGasPrice).toBe(25n);
+    expect(fees.distribution.receiptFeeMaxGasPrice).toBe(25n);
+  });
+
+  it("throws instead of building a zero receipt gas price cap when policy is enabled", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+        if (functionName === "GENPerTimeUnit") return 10n;
+        if (functionName === "storageUnitPrice") return 0n;
+        if (functionName === "quoteGasPrice") return 0n;
+        if (functionName === "messageFeeParamsBudgetFloor") return 1_234n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+      getGasPrice: vi.fn().mockResolvedValue(0n),
+    };
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    await expect(actions.estimateTransactionFees()).rejects.toThrow(
+      "receipt gas price quoted as zero; refusing to build a zero price cap",
+    );
+  });
+
+  it("does not fetch network gas price when FeeManager policy is disabled", async () => {
+    const publicClient = {
+      readContract: vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+        if (functionName === "GENPerTimeUnit") return 0n;
+        if (functionName === "storageUnitPrice") return 0n;
+        if (functionName === "quoteGasPrice") return 0n;
+        if (functionName === "messageFeeParamsBudgetFloor") return 0n;
+        if (functionName === "calculateRoundFees") return 0n;
+        throw new Error(`unexpected readContract ${functionName}`);
+      }),
+      getGasPrice: vi.fn().mockResolvedValue(0n),
+    };
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      publicClient,
+      feeManagerAddress: "0x00000000000000000000000000000000000000fe",
+    });
+
+    const fees = await actions.estimateTransactionFees();
+
+    expect(publicClient.getGasPrice).not.toHaveBeenCalled();
+    expect(fees.policy.enabled).toBe(false);
+    expect(fees.distribution.receiptFeeMaxGasPrice).toBe(0n);
   });
 
   it("defaults total message fees from root and external message allocation budgets", async () => {
@@ -733,6 +816,7 @@ describe("contractActions addTransaction ABI compatibility", () => {
         if (functionName === "calculateRoundFees") return 77n;
         throw new Error(`unexpected readContract ${functionName}`);
       }),
+      getGasPrice: vi.fn().mockResolvedValue(1n),
     };
     const {actions} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
@@ -946,10 +1030,17 @@ describe("contractActions addTransaction ABI compatibility", () => {
       priceCapHeadroomBps: 10_000n,
     });
 
+    const observedExecutionBudget = 100n + 501_664n;
+    const observedExecutionBudgetWithHeadroom = (observedExecutionBudget * 12_000n + 9_999n) / 10_000n;
+    const expectedExecutionBudgetPerRound = observedExecutionBudgetWithHeadroom > 400_000n
+      ? observedExecutionBudgetWithHeadroom
+      : 400_000n;
+    expect(expectedExecutionBudgetPerRound).toBe(602_117n);
+
     expect(fees.observed).toEqual({
       executionFeeConsumed: 100n,
       executionFeeReportTotal: 501_664n,
-      recommendedExecutionBudgetPerRound: 3_000_000_000n,
+      recommendedExecutionBudgetPerRound: expectedExecutionBudgetPerRound,
       genvmMessageFeeConsumed: 5n,
       messageFeeBudget: 10n,
       messageFeeConsumed: 5n,
@@ -960,9 +1051,47 @@ describe("contractActions addTransaction ABI compatibility", () => {
       externalMessageRemainder: 0n,
       recommendedTotalMessageFees: 6n,
     });
-    expect(fees.distribution.executionBudgetPerRound).toBe(3_000_000_000n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(expectedExecutionBudgetPerRound);
     expect(fees.distribution.totalMessageFees).toBe(6n);
-    expect(fees.feeValue).toBe(3_000_011_006n);
+    expect(fees.feeValue).toBe(613_123n);
+  });
+
+  it("uses the execution budget floor for simulation recommendations when observed usage is lower", async () => {
+    const requestMock = vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "sim_getFeeConfig") {
+        return {
+          enabled: true,
+          policy: {
+            genPerTimeUnit: "10",
+            storageUnitPrice: "20",
+            receiptGasPrice: "30",
+            messageFeeParamsBudgetFloor: "400000",
+          },
+        };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const {actions} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      isStudio: true,
+      requestMock,
+    });
+
+    const fees = await actions.estimateTransactionFeesFromSimulation({
+      simulation: {
+        feeAccounting: {
+          execution_fee_consumed: "100",
+          execution_fee_report: {
+            totalEstimatedFee: "100",
+          },
+        },
+      },
+    });
+
+    const observedExecutionBudgetWithHeadroom = ((100n + 100n) * 12_000n + 9_999n) / 10_000n;
+    expect(observedExecutionBudgetWithHeadroom).toBe(240n);
+    expect(fees.observed?.recommendedExecutionBudgetPerRound).toBe(400_000n);
+    expect(fees.distribution.executionBudgetPerRound).toBe(400_000n);
   });
 
   it("builds a Studio trusted fee preset for a target write in one call", async () => {
@@ -1064,7 +1193,7 @@ describe("contractActions addTransaction ABI compatibility", () => {
     expect(simCall.params[0].fees.feeValue).toBe("3000311110");
     expect(simCall.params[0].fees.distribution.totalMessageFees).toBe("110");
     expect(simCall.params[0].fees.messageAllocations[0].budget).toBe("110");
-    expect(fees.observed?.recommendedExecutionBudgetPerRound).toBe(3_000_000_000n);
+    expect(fees.observed?.recommendedExecutionBudgetPerRound).toBe(602_117n);
     expect(fees.observed?.messageFeeBudget).toBe(110n);
     expect(fees.observed?.messageFeeConsumed).toBe(50n);
     expect(fees.distribution.executionBudgetPerRound).toBe(3_000_000_000n);
@@ -1404,6 +1533,24 @@ describe("contractActions addTransaction ABI compatibility", () => {
     await expect(
       actions.writeContract({address: RECIPIENT_ADDRESS, functionName: "ping", value: 0n}),
     ).rejects.toThrow("Transaction reverted");
+  });
+
+  it("decodes BudgetTooLow selector from gas estimation failures", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+    const {actions, estimateTransactionGas, client} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
+      signTransactionMock: signTransaction,
+      publicClient: makeMockPublicClient({status: "reverted", logs: []}),
+    });
+    estimateTransactionGas.mockRejectedValueOnce(new Error("execution reverted: 0x305e533c"));
+    (client as any).sendRawTransaction = vi.fn().mockResolvedValue(MOCK_EVM_TX_HASH);
+
+    await expect(
+      actions.writeContract({address: RECIPIENT_ADDRESS, functionName: "ping", value: 0n}),
+    ).rejects.toThrow(/BudgetTooLow/);
+
+    consoleError.mockRestore();
   });
 
   it("throws when external wallet receipt has no NewTransaction event", async () => {

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { TransactionStatus, DECIDED_STATES, isDecidedState } from "../src/types/transactions";
-import { receiptActions, transactionActions } from "../src/transactions/actions";
+import {
+  TransactionStatus,
+  TransactionResult,
+  ExecutionResult,
+  DECIDED_STATES,
+  isDecidedState,
+  transactionsStatusNumberToName,
+  transactionResultNumberToName,
+  executionResultNumberToName,
+} from "../src/types/transactions";
+import { receiptActions, transactionActions, isSuccessful } from "../src/transactions/actions";
 import { decodeTransaction, simplifyTransactionReceipt } from "../src/transactions/decoders";
 import { localnet } from "../src/chains/localnet";
 import type { GenLayerRawTransaction } from "../src/types/transactions";
@@ -33,7 +42,7 @@ describe("isDecidedState utility function", () => {
   });
 
   it("should return false for non-decided states", () => {
-    const nonDecidedStatusNumbers = ["0", "1", "2", "3", "4", "9", "10", "11"]; // UNINITIALIZED, PENDING, PROPOSING, COMMITTING, REVEALING, APPEAL_REVEALING, APPEAL_COMMITTING, READY_TO_FINALIZE
+    const nonDecidedStatusNumbers = ["0", "1", "2", "3", "4", "9", "10", "11", "14"]; // transient states
     
     nonDecidedStatusNumbers.forEach(statusNum => {
       expect(isDecidedState(statusNum)).toBe(false);
@@ -49,9 +58,96 @@ describe("isDecidedState utility function", () => {
   });
 });
 
+describe("transaction enum maps", () => {
+  it("maps v0.6 transaction status, vote type, and result type values", () => {
+    expect(transactionsStatusNumberToName["14"]).toBe(TransactionStatus.LEADER_REVEALING);
+    expect(isDecidedState("14")).toBe(false);
+    expect(executionResultNumberToName["3"]).toBe(ExecutionResult.TIMEOUT);
+    expect(executionResultNumberToName["4"]).toBe(ExecutionResult.NONDET_DISAGREE);
+    expect(transactionResultNumberToName).toEqual({
+      "0": TransactionResult.IDLE,
+      "1": TransactionResult.MAJORITY_AGREE,
+      "2": TransactionResult.MAJORITY_DISAGREE,
+      "3": TransactionResult.MAJORITY_TIMEOUT,
+      "4": TransactionResult.DETERMINISTIC_VIOLATION,
+      "5": TransactionResult.NO_MAJORITY,
+    });
+  });
+});
+
+describe("isSuccessful", () => {
+  it("returns true only for accepted/finalized transactions that finished with return", () => {
+    expect(isSuccessful({
+      statusName: TransactionStatus.ACCEPTED,
+      txExecutionResultName: ExecutionResult.FINISHED_WITH_RETURN,
+    } as any)).toBe(true);
+    expect(isSuccessful({
+      status: 7,
+      txExecutionResult: 1,
+    } as any)).toBe(true);
+    expect(isSuccessful({
+      statusName: TransactionStatus.UNDETERMINED,
+      txExecutionResultName: ExecutionResult.FINISHED_WITH_RETURN,
+    } as any)).toBe(false);
+    expect(isSuccessful({
+      statusName: TransactionStatus.ACCEPTED,
+      txExecutionResultName: ExecutionResult.FINISHED_WITH_ERROR,
+    } as any)).toBe(false);
+    expect(isSuccessful({
+      statusName: TransactionStatus.CANCELED,
+      txExecutionResultName: ExecutionResult.FINISHED_WITH_RETURN,
+    } as any)).toBe(false);
+  });
+});
+
 describe("waitForTransactionReceipt with DECIDED_STATES", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  it("resolves waitUntil decided on UNDETERMINED", async () => {
+    const mockTransaction = {
+      hash: "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+      status: "6",
+    };
+    const mockClient = {
+      chain: localnet,
+      getTransaction: vi.fn().mockResolvedValue(mockTransaction)
+    };
+
+    const actions = receiptActions(mockClient as any, {} as any);
+    const result = await actions.waitForTransactionReceipt({
+      hash: "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6" as any,
+      waitUntil: "decided",
+    });
+
+    expect(result).toEqual(mockTransaction);
+  });
+
+  it("keeps legacy ACCEPTED status behavior and warns once", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockTransaction = {
+      hash: "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+      status: "6",
+    };
+    const mockClient = {
+      chain: localnet,
+      getTransaction: vi.fn().mockResolvedValue(mockTransaction)
+    };
+    const actions = receiptActions(mockClient as any, {} as any);
+
+    await actions.waitForTransactionReceipt({
+      hash: "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6" as any,
+      status: TransactionStatus.ACCEPTED,
+    });
+    await actions.waitForTransactionReceipt({
+      hash: "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6" as any,
+      status: TransactionStatus.ACCEPTED,
+    });
+
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn.mock.calls[0][0]).toContain("waitForTransactionReceipt({ status }) is deprecated");
+    consoleWarn.mockRestore();
   });
 
   it("should accept all decided states when waiting for ACCEPTED", async () => {
@@ -270,7 +366,7 @@ describe("decodeTransaction", () => {
     expect(decoded.numOfInitialValidators).toBe("3");
     expect(decoded.txSlot).toBe("5");
     expect(decoded.statusName).toBe("ACCEPTED");
-    expect(decoded.resultName).toBe("AGREE");
+    expect(decoded.resultName).toBe("MAJORITY_AGREE");
   });
 
   it("should handle Bradbury field: initialRotations instead of numOfInitialValidators", () => {


### PR DESCRIPTION
Implements the fee-system designer rulings from the 2026-06-09 fee-integration walkthrough.

## Estimation correctness
- **Receipt gas price**: `max(quoteGasPrice(), eth_gasPrice)` — `quoteGasPrice()` returns `tx.gasprice`, which is ~0 under a plain `eth_call` on chain-derived networks. A zero effective price on an enabled policy now **throws** instead of silently building a zero cap (consensus rejects those with `FeeValueMustBeNonZero(6)` since CON-547 — this was the root cause of the dev-env stale-cap mystery reverts).
- **Effective budget floor**: `max(on-chain messageFeeParamsBudgetFloor(), receiptPrice × 306,192 gas)` — the on-chain view multiplies by the same ~0 quote, so it can falsely read 0. 306,192 = `estimateProposeReceiptGas(MIN_RECEIPT_BYTES=512)`.
- **Simulation budgets no longer clobbered**: simulation-derived `recommendedExecutionBudgetPerRound = max(floor, observed × headroom)`; the provisional 100M-gas default applies only to the no-simulation fallback (exported, documented, `TODO(data)` for a telemetry-derived value).

## Wait semantics (designer: the behavior was right, the name was legacy-wrong)
- `waitUntil: 'decided' | 'finalized'` replaces `status`; legacy param maps ACCEPTED→decided / FINALIZED→finalized with a one-time deprecation warning.
- New `isSuccessful(tx)`: status ∈ {ACCEPTED, FINALIZED} **and** FINISHED_WITH_RETURN — acceptance alone is not success; the execution result alone is not either (it's the leader's result and exists even on UNDETERMINED).

## v0.6 ABI completeness
- Status 14 LEADER_REVEALING; VoteType 3 TIMEOUT / 4 NONDET_DISAGREE; ResultType remapped to v0.6 (dead v0.5 entries removed).
- Revert selectors: BudgetTooLow `0x305e533c`, RollupBudgetBelowFloor `0xa70732ee`, FeeValueMustBeNonZero `0x632be5a1`.
- `DEPLOY_CALL_KEY = bytes32(1)` (deploy callKey sentinel — pairs with the pending GenVM change; bytes32(0) stays the wildcard).
- `fullTransaction`/`waitUntil` added to `ITransactionActions`.

Verified: 84/84 unit tests, build green, and the dev-env E2E fee slice (051) passes against a live 5-validator stack with this SDK linked.