### PR TITLE
fix(fees)!: move wildcard callKey sentinel to keccak256(empty), deploy key = bytes32(0)

### DIFF
--- a/src/transactions/fees.ts
+++ b/src/transactions/fees.ts
@@ -13,9 +13,13 @@ import {
 } from "@/types";
 
 export const MESSAGE_ALLOCATION_ROOT_PARENT_INDEX = (1n << 256n) - 1n;
-export const CALL_KEY_WILDCARD = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
-export const CALL_KEY_UNNAMED = CALL_KEY_WILDCARD;
-export const DEPLOY_CALL_KEY = "0x0000000000000000000000000000000000000000000000000000000000000001" as const;
+// Wildcard sentinel = keccak256 of empty bytes, untagged. Reserved: it can never be a
+// derived key — short names (<32B) are left-aligned with a zero tail byte, long names
+// get the low bit forced to 1, and this hash has neither.
+export const CALL_KEY_WILDCARD = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" as const;
+// Empty method name derives bytes32(0); GenVM emits it for deploy and emit_transfer.
+export const CALL_KEY_UNNAMED = "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+export const DEPLOY_CALL_KEY = CALL_KEY_UNNAMED;
 export const CALL_KEY_DEPLOY = DEPLOY_CALL_KEY;
 
 export const deployCallKey = (): Hex => DEPLOY_CALL_KEY;

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -3,6 +3,7 @@ import {decodeAbiParameters, decodeFunctionData, encodeFunctionData, keccak256, 
 import {contractActions} from "../src/contracts/actions";
 import {
   CALL_KEY_DEPLOY,
+  CALL_KEY_UNNAMED,
   CALL_KEY_WILDCARD,
   DEPLOY_CALL_KEY,
   deployCallKey,
@@ -434,14 +435,20 @@ describe("contractActions addTransaction ABI compatibility", () => {
       `${hashed.slice(0, -2)}${lastByte.toString(16).padStart(2, "0")}`,
     );
 
-    expect(deriveInternalMessageCallKey()).toBe(CALL_KEY_WILDCARD);
-    expect(DEPLOY_CALL_KEY).toBe("0x0000000000000000000000000000000000000000000000000000000000000001");
+    // Wildcard is the untagged hash of empty bytes — outside the derived-key space.
+    expect(CALL_KEY_WILDCARD).toBe(keccak256(new Uint8Array(0)));
+    expect(CALL_KEY_WILDCARD).toBe("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+
+    // Empty name derives bytes32(0): the natural key for deploy and emit_transfer.
+    expect(deriveInternalMessageCallKey()).toBe(CALL_KEY_UNNAMED);
+    expect(CALL_KEY_UNNAMED).toBe(`0x${"00".repeat(32)}`);
+    expect(DEPLOY_CALL_KEY).toBe(CALL_KEY_UNNAMED);
     expect(CALL_KEY_DEPLOY).toBe(DEPLOY_CALL_KEY);
     expect(deployCallKey()).toBe(DEPLOY_CALL_KEY);
     expect(deriveExternalMessageCallKey("0xaabbccdd11223344")).toBe(
       `0xaabbccdd${"0".repeat(56)}`,
     );
-    expect(deriveExternalMessageCallKey("0x123456")).toBe(CALL_KEY_WILDCARD);
+    expect(deriveExternalMessageCallKey("0x123456")).toBe(CALL_KEY_UNNAMED);
   });
 
   it("encodes addTransaction with 5 args when ABI has 5 inputs", async () => {


### PR DESCRIPTION
## Context

Closes out the deploy/wildcard callKey collision (fee-audit Q2b/Q2c, revised per GenVM team input).

`bytes32(0)` is GenVM's **natural** empty-method-name key — emitted for deploy and `emit_transfer`. The wildcard sentinel also being `bytes32(0)` made deploy-specific Mode-2 allocations impossible. Instead of asking GenVM to emit a new deploy sentinel (`bytes32(1)`, now withdrawn), the **wildcard** moves off zero:

- `CALL_KEY_WILDCARD` = untagged `keccak256("")` = `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
  Provably outside the derived-key space: short names (<32B) are left-aligned with a zero tail byte, long names get the low bit forced to 1 — this hash has neither.
- `DEPLOY_CALL_KEY` / `CALL_KEY_DEPLOY` = `CALL_KEY_UNNAMED` = `bytes32(0)` — matches what GenVM actually emits. The `bytes32(1)` value from #187 was never live anywhere (v2 unpublished).
- `CALL_KEY_UNNAMED` is decoupled from the wildcard (it used to alias it); `deriveInternalMessageCallKey("")` and short-calldata external keys still return `bytes32(0)`, which is now correct as a concrete key.
- Default callKey for allocations that omit it stays "wildcard" — only the constant's value changes. CLI inherits via its SDK import on next re-pin.

## Coordination

Must land together in v0.6 with:
- consensus: `CALL_KEY_WILDCARD` constant in `MessageFeeAllocations.sol`
- node: Mode-2 tree decode (`convertConsensusAllocationNode`) — map new hash → GenVM wildcard, pass `bytes32(0)` through as a concrete key
- genlayer-py: mirror PR genlayerlabs/genlayer-py#93

No migration concern: no allocation trees exist on any deployed network.

## Testing

`vitest run` — 84 passed; `tsc --noEmit` clean. New test asserts `CALL_KEY_WILDCARD === keccak256(new Uint8Array(0))`.


Depends-On: genlayerlabs/genlayer-py#93
