### PR TITLE
feat(calldata)!: move method-call key from "method" to "" (empty string)

### DIFF
--- a/src/abi/calldata/encoder.ts
+++ b/src/abi/calldata/encoder.ts
@@ -142,6 +142,8 @@ export function encode(data: CalldataEncodable): Uint8Array {
 }
 
 // Constructs a calldata object for contract calls, omitting empty args/kwargs for compactness.
+// Method names use the empty-string key, which sorts first in canonical calldata encoding
+// and makes the method name a prefix of the encoded binary.
 export function makeCalldataObject(
   method: string | undefined,
   args: CalldataEncodable[] | undefined,
@@ -150,7 +152,7 @@ export function makeCalldataObject(
   let ret: {[key: string]: CalldataEncodable} = {};
 
   if (method) {
-    ret["method"] = method;
+    ret[""] = method;
   }
 
   if (args && args.length > 0) {

--- a/tests/calldata.test.ts
+++ b/tests/calldata.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest";
+import {calldata} from "@/abi";
+import type {CalldataEncodable} from "@/types/calldata";
+
+function decodeMap(data: Uint8Array): Map<string, CalldataEncodable> {
+  const decoded = calldata.decode(data);
+  expect(decoded).toBeInstanceOf(Map);
+  return decoded as Map<string, CalldataEncodable>;
+}
+
+describe("calldata method-call encoding", () => {
+  it("encodes method calls with the empty-string method key", () => {
+    const encoded = calldata.encode(calldata.makeCalldataObject("my_method", [1n, 2n], undefined));
+    const decoded = decodeMap(encoded);
+
+    expect(decoded.has("")).toBe(true);
+    expect(decoded.get("")).toBe("my_method");
+    expect(decoded.has("method")).toBe(false);
+  });
+
+  it("orders the empty method key before args in the encoded map body", () => {
+    const encoded = calldata.encode(calldata.makeCalldataObject("my_method", [1n, 2n], undefined));
+    const decoded = decodeMap(encoded);
+
+    expect(Array.from(decoded.entries())[0]).toEqual(["", "my_method"]);
+  });
+
+  it("orders the empty method key before kwargs in the encoded map body", () => {
+    const encoded = calldata.encode(calldata.makeCalldataObject("my_method", undefined, {count: 1n}));
+    const decoded = decodeMap(encoded);
+
+    expect(Array.from(decoded.entries())[0]).toEqual(["", "my_method"]);
+    expect(decoded.has("kwargs")).toBe(true);
+  });
+});


### PR DESCRIPTION
Depends-On: https://github.com/genlayerlabs/genlayer-studio/pull/1697
Depends-On: https://github.com/genlayerlabs/genlayer-py/pull/96
Depends-On: https://github.com/genlayerlabs/genlayer-js/pull/192
Depends-On: https://github.com/genlayerlabs/genlayer-testing-suite/pull/98

Migrate the calldata ABI to the genvm-manager v0.6 method-call wire format.

## Wire-format change
The method-call calldata map key moves from `"method"` to `""` (empty string). In canonical
calldata map encoding, keys are ordered by their unicode-codepoint array and the empty array
precedes any non-empty key — so `""` sorts first and the method name becomes a **prefix** of
the encoded binary calldata (ahead of `args` / `kwargs`).

The v0.6 genvm-manager still auto-remaps `"method"` -> `""`, but it logs an error on every
call while doing so. This migration stops that error by emitting the new key natively.

## What changed
- **`src/abi/calldata/encoder.ts`** — `makeCalldataObject` now writes the method name under
  `ret[""]` instead of `ret["method"]`. This flows through every SDK path that builds
  method-call calldata: writes (`addTransaction`), reads/view calls (`sim_call`), and the
  schema call. Deploy calldata uses `method === undefined` (no method key) and is unaffected.
- **Decoder unchanged** — `src/abi/calldata/decoder.ts` builds a generic `Map` from raw key
  bytes and already reads whatever key is present; it needs no change.
- **`tests/calldata.test.ts`** (new) — asserts the decoded map has key `""` == the method
  name, does **not** have `"method"`, and that `""` is the first entry (sorts before both
  `args` and `kwargs`). These assertions fail under the old `"method"` key (verified).

## No back-compat toggle
This repo has no calldata versioning mechanism, so this is a hard cutover per the migration
scope. Peers must run the v0.6 genvm-manager (or a node/studio build expecting the `""` key).

## Verification
- `vitest run --typecheck`: 88/88 tests pass, no type errors
- `npm run build`: green
- `eslint` on touched files: clean

## BREAKING CHANGE
Method-call calldata now uses the `""` key instead of `"method"`. Encoded bytes for every
write/read/view/schema call change.