### PR TITLE
feat(sdk): developer-NFT read/claim actions + nonce coercion fix

### DIFF
--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -4,3 +4,4 @@ import * as tx from "./transactions"
 export const calldata = cd;
 export const transactions = tx;
 export {STAKING_ABI, VALIDATOR_WALLET_ABI} from "./staking";
+export {ADDRESS_MANAGER_ABI, NFT_MINTER_ABI} from "./nftMinter";

--- a/src/abi/nftMinter.ts
+++ b/src/abi/nftMinter.ts
@@ -1,0 +1,92 @@
+export const ADDRESS_MANAGER_ABI = [
+  {
+    inputs: [{internalType: "string", name: "key", type: "string"}],
+    name: "getAddressNonZero",
+    outputs: [{internalType: "address", name: "addr", type: "address"}],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export const NFT_MINTER_ABI = [
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "claim",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {internalType: "uint256", name: "nftId", type: "uint256"},
+      {internalType: "uint256", name: "numberOfEpochsToClaim", type: "uint256"},
+    ],
+    name: "claimEpochs",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "address", name: "developer", type: "address"}],
+    name: "developerToNFT",
+    outputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "getClaimableRewardsFromFees",
+    outputs: [{internalType: "uint256", name: "", type: "uint256"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {internalType: "uint256", name: "nftId", type: "uint256"},
+      {internalType: "uint256", name: "numberOfEpochsToClaim", type: "uint256"},
+    ],
+    name: "getClaimableRewardsFromInflation",
+    outputs: [{internalType: "uint256", name: "amount", type: "uint256"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "getGhostsForNFT",
+    outputs: [{internalType: "address[]", name: "", type: "address[]"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "getLastClaimedEpoch",
+    outputs: [{internalType: "uint256", name: "", type: "uint256"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "getNumberOfEpochsToClaim",
+    outputs: [{internalType: "uint256", name: "", type: "uint256"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "address", name: "developer", type: "address"}],
+    name: "hasNFT",
+    outputs: [{internalType: "bool", name: "", type: "bool"}],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{internalType: "uint256", name: "nftId", type: "uint256"}],
+    name: "nfts",
+    outputs: [
+      {internalType: "address", name: "developer", type: "address"},
+      {internalType: "uint256", name: "claimableRewards", type: "uint256"},
+      {internalType: "uint256", name: "lastClaimedEpoch", type: "uint256"},
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -36,10 +36,14 @@ export function accountActions(client: GenLayerClient<GenLayerChain>) {
       if (!addressToUse) {
         throw new Error("No address provided and no account is connected");
       }
-      return client.request({
+      const count = await client.request({
         method: "eth_getTransactionCount",
         params: [addressToUse, block],
-      }) as Promise<number>;
+      });
+      // The RPC returns a hex quantity string; callers (and the declared return
+      // type) expect a number. Passing the raw string into viem's transaction
+      // serializer encodes the ASCII characters as the nonce bytes.
+      return Number(count);
     },
   };
 }

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -1,9 +1,11 @@
 import * as calldata from "@/abi/calldata";
 import {serialize} from "@/abi/transactions";
+import {ADDRESS_MANAGER_ABI, NFT_MINTER_ABI} from "@/abi/nftMinter";
 
 import {
   Account,
   ContractSchema,
+  DeveloperNft,
   GenLayerChain,
   GenLayerClient,
   CalldataEncodable,
@@ -672,6 +674,124 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         args: [args.txId],
       }) as Promise<boolean>;
     },
+    /** Returns a developer's NFT reward record, or null when no NFT is registered. */
+    getDeveloperNft: async (args: {developer: Address}): Promise<DeveloperNft | null> => {
+      const nftMinterAddress = await _resolveNftMinterAddress({client, publicClient});
+      const nftId = await publicClient.readContract({
+        address: nftMinterAddress,
+        abi: NFT_MINTER_ABI,
+        functionName: "developerToNFT",
+        args: [args.developer],
+      }) as bigint;
+
+      if (nftId === 0n) {
+        return null;
+      }
+
+      const [nftData, ghosts] = await Promise.all([
+        publicClient.readContract({
+          address: nftMinterAddress,
+          abi: NFT_MINTER_ABI,
+          functionName: "nfts",
+          args: [nftId],
+        }),
+        publicClient.readContract({
+          address: nftMinterAddress,
+          abi: NFT_MINTER_ABI,
+          functionName: "getGhostsForNFT",
+          args: [nftId],
+        }),
+      ]) as [
+        readonly [Address, bigint, bigint] & {
+          developer?: Address;
+          claimableRewards?: bigint;
+          lastClaimedEpoch?: bigint;
+        },
+        Address[],
+      ];
+
+      return {
+        nftId,
+        developer: nftData.developer ?? nftData[0],
+        claimableRewards: nftData.claimableRewards ?? nftData[1],
+        lastClaimedEpoch: nftData.lastClaimedEpoch ?? nftData[2],
+        ghosts,
+      };
+    },
+    /** Returns claimable developer-NFT rewards accrued from transaction fees. */
+    getClaimableRewardsFromFees: async (args: {nftId: BigNumberish}): Promise<bigint> => {
+      const nftMinterAddress = await _resolveNftMinterAddress({client, publicClient});
+      const nftId = toUInt(args.nftId, "nftId", 0n);
+      return publicClient.readContract({
+        address: nftMinterAddress,
+        abi: NFT_MINTER_ABI,
+        functionName: "getClaimableRewardsFromFees",
+        args: [nftId],
+      }) as Promise<bigint>;
+    },
+    /** Returns claimable developer-NFT rewards accrued from inflation. */
+    getClaimableRewardsFromInflation: async (args: {
+      nftId: BigNumberish;
+      numberOfEpochsToClaim: BigNumberish;
+    }): Promise<bigint> => {
+      const nftMinterAddress = await _resolveNftMinterAddress({client, publicClient});
+      const nftId = toUInt(args.nftId, "nftId", 0n);
+      const numberOfEpochsToClaim = toUInt(
+        args.numberOfEpochsToClaim,
+        "numberOfEpochsToClaim",
+        0n,
+      );
+      return publicClient.readContract({
+        address: nftMinterAddress,
+        abi: NFT_MINTER_ABI,
+        functionName: "getClaimableRewardsFromInflation",
+        args: [nftId, numberOfEpochsToClaim],
+      }) as Promise<bigint>;
+    },
+    /** Claims all currently available rewards for a developer NFT. Returns the EVM transaction hash. */
+    claimNftRewards: async (args: {
+      account?: Account;
+      nftId: BigNumberish;
+    }): Promise<`0x${string}`> => {
+      const nftMinterAddress = await _resolveNftMinterAddress({client, publicClient});
+      const encodedData = encodeFunctionData({
+        abi: NFT_MINTER_ABI,
+        functionName: "claim",
+        args: [toUInt(args.nftId, "nftId", 0n)],
+      });
+      return _sendEvmContractCall({
+        client,
+        publicClient,
+        to: nftMinterAddress,
+        encodedData,
+        senderAccount: args.account || client.account,
+        operationName: "Claim NFT rewards",
+      });
+    },
+    /** Claims a bounded number of reward epochs for a developer NFT. Returns the EVM transaction hash. */
+    claimNftEpochs: async (args: {
+      account?: Account;
+      nftId: BigNumberish;
+      numberOfEpochsToClaim: BigNumberish;
+    }): Promise<`0x${string}`> => {
+      const nftMinterAddress = await _resolveNftMinterAddress({client, publicClient});
+      const encodedData = encodeFunctionData({
+        abi: NFT_MINTER_ABI,
+        functionName: "claimEpochs",
+        args: [
+          toUInt(args.nftId, "nftId", 0n),
+          toUInt(args.numberOfEpochsToClaim, "numberOfEpochsToClaim", 0n),
+        ],
+      });
+      return _sendEvmContractCall({
+        client,
+        publicClient,
+        to: nftMinterAddress,
+        encodedData,
+        senderAccount: args.account || client.account,
+        operationName: "Claim NFT epochs",
+      });
+    },
     /** Appeals a consensus transaction to trigger a new round of validation. */
     appealTransaction: async (args: {
       account?: Account;
@@ -1002,6 +1122,77 @@ const toUInt = (value: BigNumberish | undefined, fieldName: string, fallback: bi
     throw new Error(`${fieldName} must be greater than or equal to zero.`);
   }
   return normalized;
+};
+
+const hasAbiFunction = (abi: readonly unknown[] | undefined, functionName: string): boolean => {
+  if (!Array.isArray(abi)) {
+    return false;
+  }
+  return abi.some(item => {
+    if (!item || typeof item !== "object") {
+      return false;
+    }
+    const candidate = item as {type?: string; name?: string};
+    return candidate.type === "function" && candidate.name === functionName;
+  });
+};
+
+const _resolveAddressManagerAddress = async ({
+  client,
+  publicClient,
+}: {
+  client: GenLayerClient<GenLayerChain>;
+  publicClient: PublicClient;
+}): Promise<`0x${string}`> => {
+  const consensusMainContract = client.chain.consensusMainContract;
+  if (!consensusMainContract?.address) {
+    throw new Error("NFTMinter address resolution not supported on this chain (missing consensusMainContract).");
+  }
+
+  const functionName = hasAbiFunction(consensusMainContract.abi, "getAddressManager")
+    ? "getAddressManager"
+    : hasAbiFunction(consensusMainContract.abi, "addressManager")
+      ? "addressManager"
+      : undefined;
+
+  if (!functionName) {
+    throw new Error("NFTMinter address resolution not supported on this chain (missing AddressManager getter).");
+  }
+
+  const addressManagerAddress = await publicClient.readContract({
+    address: consensusMainContract.address as `0x${string}`,
+    abi: consensusMainContract.abi as Abi,
+    functionName,
+    args: [],
+  }) as Address;
+
+  if (addressManagerAddress.toLowerCase() === zeroAddress) {
+    throw new Error("NFTMinter address resolution failed: AddressManager is zero.");
+  }
+
+  return addressManagerAddress as `0x${string}`;
+};
+
+const _resolveNftMinterAddress = async ({
+  client,
+  publicClient,
+}: {
+  client: GenLayerClient<GenLayerChain>;
+  publicClient: PublicClient;
+}): Promise<`0x${string}`> => {
+  const addressManagerAddress = await _resolveAddressManagerAddress({client, publicClient});
+  const nftMinterAddress = await publicClient.readContract({
+    address: addressManagerAddress,
+    abi: ADDRESS_MANAGER_ABI,
+    functionName: "getAddressNonZero",
+    args: ["NFTMinter"],
+  }) as Address;
+
+  if (nftMinterAddress.toLowerCase() === zeroAddress) {
+    throw new Error("NFTMinter address resolution failed: AddressManager returned zero.");
+  }
+
+  return nftMinterAddress as `0x${string}`;
 };
 
 const getDefaultValidUntil = () => BigInt(Math.floor(Date.now() / 1000) + 3600);
@@ -1820,6 +2011,89 @@ const _encodeTopUpAndSubmitAppealData = ({
     functionName: "topUpAndSubmitAppeal",
     args: [txId, createFeesDistribution(distribution)],
   });
+};
+
+const _sendEvmContractCall = async ({
+  client,
+  publicClient,
+  to,
+  encodedData,
+  senderAccount,
+  value = 0n,
+  operationName = "Contract call",
+}: {
+  client: GenLayerClient<GenLayerChain>;
+  publicClient: PublicClient;
+  to: Address;
+  encodedData: `0x${string}`;
+  senderAccount?: Account;
+  value?: bigint;
+  operationName?: string;
+}): Promise<`0x${string}`> => {
+  const validatedAccount = validateAccount(senderAccount);
+  const nonce = await client.getCurrentNonce({address: validatedAccount.address});
+
+  let estimatedGas: bigint;
+  try {
+    estimatedGas = await client.estimateTransactionGas({
+      from: validatedAccount.address,
+      to,
+      data: encodedData,
+      value,
+    });
+  } catch (err) {
+    console.error("Gas estimation failed, using default 200_000:", err);
+    estimatedGas = 200_000n;
+  }
+
+  const gasPriceHex = (await client.request({method: "eth_gasPrice"})) as string;
+
+  if (validatedAccount.type === "local") {
+    if (!validatedAccount.signTransaction) {
+      throw new Error("Local account does not support signTransaction.");
+    }
+    const txRequest = {
+      account: validatedAccount,
+      to,
+      data: encodedData,
+      value,
+      gas: estimatedGas,
+      gasPrice: BigInt(gasPriceHex),
+      nonce,
+      chainId: client.chain.id,
+    };
+    const serializedTransaction = await validatedAccount.signTransaction(txRequest);
+    const evmHash = await client.sendRawTransaction({serializedTransaction});
+    if (client.chain.isStudio) {
+      return evmHash;
+    }
+    const receipt = await publicClient.waitForTransactionReceipt({hash: evmHash});
+    if (receipt.status === "reverted") {
+      throw new Error(`${operationName} reverted: EVM tx ${evmHash}`);
+    }
+    return evmHash;
+  }
+
+  const evmHash = (await client.request({
+    method: "eth_sendTransaction",
+    params: [{
+      from: validatedAccount.address,
+      to,
+      data: encodedData,
+      value: value ? (`0x${value.toString(16)}` as `0x${string}`) : undefined,
+      gas: `0x${estimatedGas.toString(16)}` as `0x${string}`,
+      nonce: `0x${BigInt(nonce).toString(16)}` as `0x${string}`,
+      gasPrice: gasPriceHex as `0x${string}`,
+    }],
+  })) as `0x${string}`;
+  if (client.chain.isStudio) {
+    return evmHash;
+  }
+  const receipt = await publicClient.waitForTransactionReceipt({hash: evmHash});
+  if (receipt.status === "reverted") {
+    throw new Error(`${operationName} reverted: EVM tx ${evmHash}`);
+  }
+  return evmHash;
 };
 
 /**

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -19,7 +19,7 @@ import {
 import {GenLayerChain} from "./chains";
 import {Address, Account} from "./accounts";
 import {CalldataEncodable} from "./calldata";
-import {ContractSchema} from "./contracts";
+import {ContractSchema, DeveloperNft} from "./contracts";
 import {Network} from "./network";
 import {SnapSource} from "@/types/snapSource";
 import {MetaMaskClientResult} from "@/types/metamaskClientResult";
@@ -143,6 +143,21 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
     getRoundData: (args: {txId: `0x${string}`; round: bigint}) => Promise<any>;
     getLastRoundData: (args: {txId: `0x${string}`}) => Promise<any>;
     canAppeal: (args: {txId: `0x${string}`}) => Promise<boolean>;
+    getDeveloperNft: (args: {developer: Address}) => Promise<DeveloperNft | null>;
+    getClaimableRewardsFromFees: (args: {nftId: BigNumberish}) => Promise<bigint>;
+    getClaimableRewardsFromInflation: (args: {
+      nftId: BigNumberish;
+      numberOfEpochsToClaim: BigNumberish;
+    }) => Promise<bigint>;
+    claimNftRewards: (args: {
+      account?: Account;
+      nftId: BigNumberish;
+    }) => Promise<`0x${string}`>;
+    claimNftEpochs: (args: {
+      account?: Account;
+      nftId: BigNumberish;
+      numberOfEpochsToClaim: BigNumberish;
+    }) => Promise<`0x${string}`>;
     appealTransaction: (args: {
       account?: Account;
       txId: `0x${string}`;

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -1,3 +1,5 @@
+import {Address} from "./accounts";
+
 export type ContractParamsArraySchemaElement = ContractParamsSchema | {$rep: ContractParamsSchema};
 
 export type ContractParamsSchema =
@@ -30,3 +32,11 @@ export type ContractSchema = {
   ctor: ContractMethodBase;
   methods: Record<string, ContractMethod>;
 };
+
+export interface DeveloperNft {
+  nftId: bigint;
+  developer: Address;
+  claimableRewards: bigint;
+  lastClaimedEpoch: bigint;
+  ghosts: Address[];
+}

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect, vi} from "vitest";
 import {decodeAbiParameters, decodeFunctionData, encodeFunctionData, keccak256, toHex} from "viem";
 import {contractActions} from "../src/contracts/actions";
+import {NFT_MINTER_ABI} from "../src/abi/nftMinter";
 import {
   CALL_KEY_DEPLOY,
   CALL_KEY_UNNAMED,
@@ -17,6 +18,8 @@ import {
 const MAIN_CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000001";
 const SENDER_ADDRESS = "0x0000000000000000000000000000000000000002";
 const RECIPIENT_ADDRESS = "0x0000000000000000000000000000000000000003";
+const ADDRESS_MANAGER_ADDRESS = "0x0000000000000000000000000000000000000004";
+const NFT_MINTER_ADDRESS = "0x0000000000000000000000000000000000000005";
 const MOCK_GENLAYER_TX_ID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const MOCK_EVM_TX_HASH = "0x1234000000000000000000000000000000000000000000000000000000001234";
 
@@ -33,6 +36,16 @@ const NEW_TRANSACTION_EVENT_ABI = {
 const NEW_TRANSACTION_EVENT_TOPIC = keccak256(
   toHex(new TextEncoder().encode("NewTransaction(bytes32,address,address)")),
 );
+
+const CONSENSUS_ADDRESS_MANAGER_ABI = [
+  {
+    type: "function",
+    name: "getAddressManager",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{name: "", type: "address"}],
+  },
+] as const;
 
 const makeMockReceiptWithNewTxEvent = (txId: string = MOCK_GENLAYER_TX_ID) => ({
   status: "success" as const,
@@ -264,6 +277,188 @@ const setupWriteContractHarness = ({
 
   return {actions, estimateTransactionGas, client, signTransaction, publicClient};
 };
+
+const setupDeveloperNftHarness = ({
+  readContractMock,
+  signTransactionMock,
+}: {
+  readContractMock?: ReturnType<typeof vi.fn>;
+  signTransactionMock?: ReturnType<typeof vi.fn>;
+} = {}) => {
+  const estimateTransactionGas = vi.fn().mockResolvedValue(21_000n);
+  const signTransaction = signTransactionMock ?? vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+  const readContract = readContractMock ?? vi.fn().mockImplementation(async ({
+    functionName,
+    args,
+  }: {
+    functionName: string;
+    args?: readonly unknown[];
+  }) => {
+    if (functionName === "getAddressManager") return ADDRESS_MANAGER_ADDRESS;
+    if (functionName === "getAddressNonZero") {
+      expect(args).toEqual(["NFTMinter"]);
+      return NFT_MINTER_ADDRESS;
+    }
+    if (functionName === "developerToNFT") return 7n;
+    if (functionName === "nfts") return [SENDER_ADDRESS, 123n, 5n];
+    if (functionName === "getGhostsForNFT") return [RECIPIENT_ADDRESS];
+    if (functionName === "getClaimableRewardsFromFees") return 123n;
+    if (functionName === "getClaimableRewardsFromInflation") return 456n;
+    throw new Error(`Unexpected readContract ${functionName}`);
+  });
+
+  const publicClient = {
+    readContract,
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({status: "success"}),
+  };
+  const client = {
+    chain: {
+      id: 61_127,
+      isStudio: false,
+      consensusMainContract: {
+        address: MAIN_CONTRACT_ADDRESS,
+        abi: CONSENSUS_ADDRESS_MANAGER_ABI,
+        bytecode: "0x",
+      },
+    },
+    account: {
+      address: SENDER_ADDRESS,
+      type: "local",
+      signTransaction,
+    },
+    getCurrentNonce: vi.fn().mockResolvedValue(0n),
+    estimateTransactionGas,
+    request: vi.fn().mockImplementation(async ({method}: {method: string}) => {
+      if (method === "eth_gasPrice") {
+        return "0x1";
+      }
+      throw new Error(`Unexpected RPC method: ${method}`);
+    }),
+    sendRawTransaction: vi.fn().mockResolvedValue(MOCK_EVM_TX_HASH),
+  };
+
+  const actions = contractActions(client as any, publicClient as any);
+
+  return {actions, client, estimateTransactionGas, publicClient, readContract, signTransaction};
+};
+
+describe("contractActions developer NFT actions", () => {
+  it("returns developer NFT data from the AddressManager-resolved NFTMinter", async () => {
+    const {actions, readContract} = setupDeveloperNftHarness();
+
+    const nft = await actions.getDeveloperNft({developer: SENDER_ADDRESS});
+
+    expect(nft).toEqual({
+      nftId: 7n,
+      developer: SENDER_ADDRESS,
+      claimableRewards: 123n,
+      lastClaimedEpoch: 5n,
+      ghosts: [RECIPIENT_ADDRESS],
+    });
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: MAIN_CONTRACT_ADDRESS,
+      functionName: "getAddressManager",
+      args: [],
+    }));
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: ADDRESS_MANAGER_ADDRESS,
+      functionName: "getAddressNonZero",
+      args: ["NFTMinter"],
+    }));
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: NFT_MINTER_ADDRESS,
+      functionName: "developerToNFT",
+      args: [SENDER_ADDRESS],
+    }));
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: NFT_MINTER_ADDRESS,
+      functionName: "nfts",
+      args: [7n],
+    }));
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: NFT_MINTER_ADDRESS,
+      functionName: "getGhostsForNFT",
+      args: [7n],
+    }));
+  });
+
+  it("returns null when a developer has no NFT", async () => {
+    const readContract = vi.fn().mockImplementation(async ({functionName}: {functionName: string}) => {
+      if (functionName === "getAddressManager") return ADDRESS_MANAGER_ADDRESS;
+      if (functionName === "getAddressNonZero") return NFT_MINTER_ADDRESS;
+      if (functionName === "developerToNFT") return 0n;
+      throw new Error(`Unexpected readContract ${functionName}`);
+    });
+    const {actions} = setupDeveloperNftHarness({readContractMock: readContract});
+
+    await expect(actions.getDeveloperNft({developer: SENDER_ADDRESS})).resolves.toBeNull();
+    expect(readContract).not.toHaveBeenCalledWith(expect.objectContaining({
+      functionName: "nfts",
+    }));
+  });
+
+  it("reads claimable rewards from fees and inflation on NFTMinter", async () => {
+    const {actions, readContract} = setupDeveloperNftHarness();
+
+    await expect(actions.getClaimableRewardsFromFees({nftId: 7n})).resolves.toBe(123n);
+    await expect(
+      actions.getClaimableRewardsFromInflation({
+        nftId: 7n,
+        numberOfEpochsToClaim: 3n,
+      }),
+    ).resolves.toBe(456n);
+
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: NFT_MINTER_ADDRESS,
+      functionName: "getClaimableRewardsFromFees",
+      args: [7n],
+    }));
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: NFT_MINTER_ADDRESS,
+      functionName: "getClaimableRewardsFromInflation",
+      args: [7n, 3n],
+    }));
+  });
+
+  it("encodes claimNftRewards to the AddressManager-resolved NFTMinter", async () => {
+    const {actions, estimateTransactionGas} = setupDeveloperNftHarness();
+
+    await expect(actions.claimNftRewards({nftId: 7n})).rejects.toThrow("stop_after_encoding");
+
+    const expectedData = encodeFunctionData({
+      abi: NFT_MINTER_ABI,
+      functionName: "claim",
+      args: [7n],
+    });
+    expect(estimateTransactionGas).toHaveBeenCalledWith(expect.objectContaining({
+      to: NFT_MINTER_ADDRESS,
+      data: expectedData,
+      value: 0n,
+    }));
+  });
+
+  it("encodes claimNftEpochs to the AddressManager-resolved NFTMinter", async () => {
+    const {actions, estimateTransactionGas} = setupDeveloperNftHarness();
+
+    await expect(
+      actions.claimNftEpochs({
+        nftId: 7n,
+        numberOfEpochsToClaim: 3n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    const expectedData = encodeFunctionData({
+      abi: NFT_MINTER_ABI,
+      functionName: "claimEpochs",
+      args: [7n, 3n],
+    });
+    expect(estimateTransactionGas).toHaveBeenCalledWith(expect.objectContaining({
+      to: NFT_MINTER_ADDRESS,
+      data: expectedData,
+      value: 0n,
+    }));
+  });
+});
 
 describe("contractActions addTransaction ABI compatibility", () => {
   it("passes trusted fees and user value through Studio simulateWriteContract sim_call", async () => {


### PR DESCRIPTION
Adds SDK support for the developer NFT reward mechanism so libraries — and the tooling e2e suite — can read and claim developer rewards, plus a nonce-serialization fix uncovered while building it.

## Developer NFT actions (`src/contracts/actions.ts`, `src/abi/nftMinter.ts`)
- `getDeveloperNft({ developer })` → `DeveloperNft | null` (`nftId`, `developer`, `claimableRewards`, `lastClaimedEpoch`, `ghosts`)
- `getClaimableRewardsFromFees({ nftId })` → `bigint`
- `getClaimableRewardsFromInflation({ nftId, numberOfEpochsToClaim })` → `bigint`
- `claimNftRewards({ nftId })` / `claimNftEpochs({ nftId, numberOfEpochsToClaim })`
- NFTMinter address resolved automatically via the on-chain AddressManager.

Verified end-to-end against a live dev-env stack — the developer-NFT accuracy e2e (`055_developer_nft_rewards`) reconciles these views to the wei against on-chain fee events and the epoch inflation formula.

## Nonce fix (`src/accounts/actions.ts`)
`getCurrentNonce` returned the RPC's hex quantity string while the declared return type (and callers) expect a `number`. On the local-account signing path the raw string flowed into viem's transaction serializer, which encoded the ASCII characters as the nonce bytes — producing an unmineable transaction and an infinite receipt wait. This bit any local-account consensus call (appeals, top-ups) on network backends; the fix coerces to `Number`.

## Tests
`npm test` (typecheck + vitest): **89 passing**. Build clean.

> Draft. Cherry-picked cleanly onto current `v2-dev` (the callkey-sentinel commit this was originally stacked on is already merged via #190).