### PR TITLE
fix: make git install build lifecycle robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "prepare": "npm run build",
-    "build": "tsup src/index.ts src/chains/index.ts src/types/index.ts --format cjs,esm --dts --splitting --out-dir dist --no-treeshake",
-    "build:watch": "tsup src/index.ts src/chains/index.ts src/types/index.ts --format cjs,esm --dts --splitting --out-dir dist --no-treeshake --watch",
+    "prepack": "npm run build",
+    "build": "node scripts/run-tsup-build.mjs",
+    "build:watch": "node scripts/run-tsup-build.mjs --watch",
     "test": "vitest --typecheck",
     "test:smoke": "vitest run --config vitest.smoke.config.ts",
     "test:watch": "vitest --watch",

--- a/scripts/run-tsup-build.mjs
+++ b/scripts/run-tsup-build.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { build } from 'tsup';
+
+const watch = process.argv.includes('--watch');
+
+await build({
+  entry: ['src/index.ts', 'src/chains/index.ts', 'src/types/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: true,
+  outDir: 'dist',
+  treeshake: false,
+  watch,
+});


### PR DESCRIPTION
## Summary

- stop running the SDK build during git installs by moving the lifecycle from `prepare` to `prepack`
- replace the `tsup` binary script with a Node wrapper so build/pack does not depend on npm-created `.bin` links

## Why

`genlayer-cli#v0.40-dev` currently pulls `genlayer-js#v2-dev` as a git dependency. npm git/global install paths can run lifecycle scripts in a cache clone where `.bin` links are unavailable. That makes scripts like `tsup ...` fail even though the package dependency is present.

The SDK already commits `dist`, so git installs should consume the checked-in build output. Release/package creation still builds through `prepack`.

## Verification

- `npm install`
- `npm run build`
- `npm install --prefix /private/tmp/genlayer-js-git-fix-test --cache /private/tmp/npm-cache-genlayer-install --foreground-scripts --loglevel=info "git+file:///Users/edgars/Dev/genlayer-js-install-fix#fix/git-install-build-script"`
