### PR TITLE
fix: build package during git prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "prepack": "npm run build",
     "build": "node scripts/run-tsup-build.mjs",
     "build:watch": "node scripts/run-tsup-build.mjs --watch",


### PR DESCRIPTION
Restores git dependency installs while keeping the build command self-contained.\n\nWhy:\n- CLI consumes genlayer-js from a Git ref on the v0.40/v2 train.\n- Removing prepare made npm install succeed without dist artifacts.\n- The previous prepare failed in git/global lifecycle contexts when shell .bin lookup could not find tsup.\n\nWhat changed:\n- Keep prepare, but have it call the existing Node wrapper build script.\n- Keep prepack for package/tarball builds.\n\nValidation:\n- npm run build\n- npm install github:genlayerlabs/genlayer-js#fix/git-install-prepare-build\n- verified node_modules/genlayer-js/dist/index.js exists and imports successfully.