### PR TITLE
feat(staking,vesting,accounts): provider-lane writes + native transfer

### DIFF
--- a/src/accounts/actions.ts
+++ b/src/accounts/actions.ts
@@ -1,7 +1,8 @@
+import {Address as ViemAddress, PublicClient, TransactionReceipt} from "viem";
 import {GenLayerClient, TransactionHash, GenLayerChain, Address} from "../types";
 import {localnet} from "../chains";
 
-export function accountActions(client: GenLayerClient<GenLayerChain>) {
+export function accountActions(client: GenLayerClient<GenLayerChain>, publicClient: PublicClient) {
   return {
     fundAccount: async ({address, amount}: {address: Address; amount: number}): Promise<TransactionHash> => {
       if (client.chain?.id !== localnet.id) {
@@ -44,6 +45,60 @@ export function accountActions(client: GenLayerClient<GenLayerChain>) {
       // type) expect a number. Passing the raw string into viem's transaction
       // serializer encodes the ASCII characters as the nonce bytes.
       return Number(count);
+    },
+    /**
+     * Sends a native GEN transfer from the connected account.
+     *
+     * Local-key only: mirrors the staking/vesting executeWrite local lane 1:1
+     * (estimateGas → pending nonce → legacy prepareTransactionRequest → sign →
+     * sendRawTransaction → wait for receipt). Address-only / injected-provider
+     * accounts are intentionally rejected — provider-signed transfers are the
+     * wallet's own responsibility.
+     */
+    transfer: async ({to, value}: {to: Address; value: bigint}): Promise<TransactionReceipt> => {
+      const account = client.account;
+      if (!account || account.type !== "local" || !account.signTransaction) {
+        throw new Error(
+          "transfer requires a local-key account. Initialize the client with a private-key account created via createAccount().",
+        );
+      }
+
+      let gasLimit: bigint;
+      try {
+        gasLimit = await publicClient.estimateGas({
+          account,
+          to: to as ViemAddress,
+          value,
+        });
+      } catch {
+        gasLimit = 21000n;
+      }
+
+      const nonce = await publicClient.getTransactionCount({
+        address: account.address as ViemAddress,
+        blockTag: "pending",
+      });
+
+      const txRequest = await publicClient.prepareTransactionRequest({
+        account,
+        to: to as ViemAddress,
+        value,
+        type: "legacy",
+        nonce,
+        gas: gasLimit,
+        chain: client.chain,
+      });
+
+      const signTransaction = account.signTransaction;
+      const serializedTx = await signTransaction(txRequest as Parameters<typeof signTransaction>[0]);
+      const hash = await publicClient.sendRawTransaction({serializedTransaction: serializedTx});
+      const receipt = await publicClient.waitForTransactionReceipt({hash});
+
+      if (receipt.status === "reverted") {
+        throw new Error(`Transfer reverted (tx: ${hash})`);
+      }
+
+      return receipt;
     },
   };
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -148,7 +148,7 @@ export const createClient = (config: ClientConfig = {chain: localnet}): GenLayer
   const clientWithBasicActions = baseClient
     .extend(publicActions)
     .extend(walletActions)
-    .extend(client => accountActions(client as unknown as GenLayerClient<GenLayerChain>));
+    .extend(client => accountActions(client as unknown as GenLayerClient<GenLayerChain>, publicClient));
 
   const clientWithTransactionActions = {
     ...clientWithBasicActions,

--- a/src/staking/actions.ts
+++ b/src/staking/actions.ts
@@ -131,25 +131,53 @@ export const stakingActions = (
       }
     }
 
-    const nonce = await publicClient.getTransactionCount({address: account.address as ViemAddress});
+    let hash: `0x${string}`;
+    if (account.type === "local") {
+      const nonce = await publicClient.getTransactionCount({address: account.address as ViemAddress});
 
-    const txRequest = await publicClient.prepareTransactionRequest({
-      account,
-      to: options.to,
-      data: options.data,
-      value: options.value,
-      type: "legacy",
-      nonce,
-      gas: gasLimit,
-      chain: client.chain,
-    });
+      const txRequest = await publicClient.prepareTransactionRequest({
+        account,
+        to: options.to,
+        data: options.data,
+        value: options.value,
+        type: "legacy",
+        nonce,
+        gas: gasLimit,
+        chain: client.chain,
+      });
 
-    const signTransaction = account.signTransaction;
-    if (!signTransaction) {
-      throw new Error("Account does not support signing transactions");
+      const signTransaction = account.signTransaction;
+      if (!signTransaction) {
+        throw new Error("Account does not support signing transactions");
+      }
+      const serializedTx = await signTransaction(txRequest as Parameters<typeof signTransaction>[0]);
+      hash = await publicClient.sendRawTransaction({serializedTransaction: serializedTx});
+    } else {
+      // Address-only / injected-provider lane: the connected wallet manages
+      // nonce and signing. Mirrors the proven IC provider lane in
+      // src/contracts/actions.ts (~:2169-2178 and :2412-2422).
+      let gasPrice: `0x${string}` | undefined;
+      try {
+        gasPrice = (await client.request({method: "eth_gasPrice"})) as `0x${string}`;
+      } catch {
+        // Best-effort: omit gasPrice and let the wallet choose it.
+      }
+      hash = (await client.request({
+        method: "eth_sendTransaction",
+        params: [
+          {
+            from: account.address,
+            to: options.to,
+            data: options.data,
+            value: options.value ? (`0x${options.value.toString(16)}` as `0x${string}`) : undefined,
+            gas: `0x${gasLimit.toString(16)}` as `0x${string}`,
+            type: "0x0",
+            ...(gasPrice ? {gasPrice} : {}),
+          },
+        ],
+      })) as `0x${string}`;
     }
-    const serializedTx = await signTransaction(txRequest as Parameters<typeof signTransaction>[0]);
-    const hash = await publicClient.sendRawTransaction({serializedTransaction: serializedTx});
+
     const receipt = await publicClient.waitForTransactionReceipt({hash});
 
     if (receipt.status === "reverted") {

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -1,4 +1,4 @@
-import {Transport, Client, PublicActions, WalletActions} from "viem";
+import {Transport, Client, PublicActions, WalletActions, TransactionReceipt} from "viem";
 import {
   GenLayerTransaction,
   TransactionHash,
@@ -114,6 +114,7 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: Address}) => Promise<number>;
+    transfer: (args: {to: Address; value: bigint}) => Promise<TransactionReceipt>;
     estimateTransactionGas: (transactionParams: {
       from?: Address;
       to: Address;

--- a/src/vesting/actions.ts
+++ b/src/vesting/actions.ts
@@ -140,25 +140,53 @@ export const vestingActions = (
       }
     }
 
-    const nonce = await publicClient.getTransactionCount({address: account.address as ViemAddress});
+    let hash: `0x${string}`;
+    if (account.type === "local") {
+      const nonce = await publicClient.getTransactionCount({address: account.address as ViemAddress});
 
-    const txRequest = await publicClient.prepareTransactionRequest({
-      account,
-      to: options.to,
-      data: options.data,
-      value: options.value,
-      type: "legacy",
-      nonce,
-      gas: gasLimit,
-      chain: client.chain,
-    });
+      const txRequest = await publicClient.prepareTransactionRequest({
+        account,
+        to: options.to,
+        data: options.data,
+        value: options.value,
+        type: "legacy",
+        nonce,
+        gas: gasLimit,
+        chain: client.chain,
+      });
 
-    const signTransaction = account.signTransaction;
-    if (!signTransaction) {
-      throw new Error("Account does not support signing transactions");
+      const signTransaction = account.signTransaction;
+      if (!signTransaction) {
+        throw new Error("Account does not support signing transactions");
+      }
+      const serializedTx = await signTransaction(txRequest as Parameters<typeof signTransaction>[0]);
+      hash = await publicClient.sendRawTransaction({serializedTransaction: serializedTx});
+    } else {
+      // Address-only / injected-provider lane: the connected wallet manages
+      // nonce and signing. Mirrors the proven IC provider lane in
+      // src/contracts/actions.ts (~:2169-2178 and :2412-2422).
+      let gasPrice: `0x${string}` | undefined;
+      try {
+        gasPrice = (await client.request({method: "eth_gasPrice"})) as `0x${string}`;
+      } catch {
+        // Best-effort: omit gasPrice and let the wallet choose it.
+      }
+      hash = (await client.request({
+        method: "eth_sendTransaction",
+        params: [
+          {
+            from: account.address,
+            to: options.to,
+            data: options.data,
+            value: options.value ? (`0x${options.value.toString(16)}` as `0x${string}`) : undefined,
+            gas: `0x${gasLimit.toString(16)}` as `0x${string}`,
+            type: "0x0",
+            ...(gasPrice ? {gasPrice} : {}),
+          },
+        ],
+      })) as `0x${string}`;
     }
-    const serializedTx = await signTransaction(txRequest as Parameters<typeof signTransaction>[0]);
-    const hash = await publicClient.sendRawTransaction({serializedTransaction: serializedTx});
+
     const receipt = await publicClient.waitForTransactionReceipt({hash});
 
     if (receipt.status === "reverted") {

--- a/tests/accounts-actions.test.ts
+++ b/tests/accounts-actions.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it, vi} from "vitest";
+import {parseEther} from "viem";
 import {accountActions} from "../src/accounts/actions";
+
+// Minimal publicClient stub for the getCurrentNonce tests, which never touch it.
+// accountActions now requires a publicClient (mandated by the transfer factory
+// signature change); these read-path tests are otherwise unchanged.
+const noopPublicClient = {} as any;
 
 function makeClient() {
   const request = vi.fn().mockResolvedValue(42);
@@ -16,7 +22,7 @@ function makeClient() {
 describe("accountActions.getCurrentNonce", () => {
   it("defaults to block=\"pending\" so concurrent submissions do not collide", async () => {
     const {client, request} = makeClient();
-    const actions = accountActions(client);
+    const actions = accountActions(client, noopPublicClient);
 
     await actions.getCurrentNonce({
       address: "0x0000000000000000000000000000000000000001",
@@ -30,7 +36,7 @@ describe("accountActions.getCurrentNonce", () => {
 
   it("honors an explicit block override", async () => {
     const {client, request} = makeClient();
-    const actions = accountActions(client);
+    const actions = accountActions(client, noopPublicClient);
 
     await actions.getCurrentNonce({
       address: "0x0000000000000000000000000000000000000001",
@@ -50,7 +56,7 @@ describe("accountActions.getCurrentNonce", () => {
       account: {address: "0x0000000000000000000000000000000000000abc"},
       chain: {id: 1},
     } as any;
-    const actions = accountActions(client);
+    const actions = accountActions(client, noopPublicClient);
 
     // Pass empty string, which is falsy per the implementation's fallback chain.
     await actions.getCurrentNonce({address: "" as any});
@@ -63,10 +69,111 @@ describe("accountActions.getCurrentNonce", () => {
 
   it("throws when neither address nor client.account is available", async () => {
     const {client} = makeClient();
-    const actions = accountActions(client);
+    const actions = accountActions(client, noopPublicClient);
 
     await expect(actions.getCurrentNonce({address: "" as any})).rejects.toThrow(
       /No address provided/,
+    );
+  });
+});
+
+const ACCOUNT_ADDRESS = "0x0000000000000000000000000000000000000011";
+const TO_ADDRESS = "0x0000000000000000000000000000000000000022";
+const MOCK_TX_HASH = "0x1234000000000000000000000000000000000000000000000000000000001234";
+
+const makeTransferReceipt = () => ({
+  status: "success" as const,
+  transactionHash: MOCK_TX_HASH as `0x${string}`,
+  blockNumber: 12n,
+  gasUsed: 21000n,
+  logs: [],
+});
+
+function makeTransferHarness() {
+  const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+  const client = {
+    account: {
+      address: ACCOUNT_ADDRESS,
+      type: "local",
+      signTransaction,
+    },
+    chain: {id: 1, name: "test"},
+  } as any;
+  const publicClient = {
+    estimateGas: vi.fn().mockResolvedValue(21000n),
+    getTransactionCount: vi.fn().mockResolvedValue(7),
+    prepareTransactionRequest: vi.fn().mockImplementation(async (request: any) => request),
+    sendRawTransaction: vi.fn().mockResolvedValue(MOCK_TX_HASH),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue(makeTransferReceipt()),
+  } as any;
+
+  return {actions: accountActions(client, publicClient), client, publicClient, signTransaction};
+}
+
+describe("accountActions.transfer", () => {
+  it("signs a legacy transfer with the pending nonce and returns the receipt", async () => {
+    const {actions, publicClient, signTransaction} = makeTransferHarness();
+
+    const receipt = await actions.transfer({to: TO_ADDRESS, value: parseEther("1")});
+
+    // Uses the pending nonce for rapid sequential sends.
+    expect(publicClient.getTransactionCount).toHaveBeenCalledWith({
+      address: ACCOUNT_ADDRESS,
+      blockTag: "pending",
+    });
+
+    const prepared = publicClient.prepareTransactionRequest.mock.calls[0][0];
+    expect(prepared).toMatchObject({
+      to: TO_ADDRESS,
+      value: parseEther("1"),
+      type: "legacy",
+      nonce: 7,
+      gas: 21000n,
+    });
+
+    expect(signTransaction).toHaveBeenCalledTimes(1);
+    expect(publicClient.sendRawTransaction).toHaveBeenCalledWith({serializedTransaction: "0xsigned"});
+    expect(receipt).toEqual(makeTransferReceipt());
+  });
+
+  it("falls back to a 21000 gas limit when estimateGas rejects", async () => {
+    const {actions, publicClient} = makeTransferHarness();
+    publicClient.estimateGas.mockRejectedValueOnce(new Error("estimate failed"));
+
+    await actions.transfer({to: TO_ADDRESS, value: parseEther("1")});
+
+    expect(publicClient.prepareTransactionRequest.mock.calls[0][0].gas).toBe(21000n);
+  });
+
+  it("throws when the transfer receipt is reverted", async () => {
+    const {actions, publicClient} = makeTransferHarness();
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+      ...makeTransferReceipt(),
+      status: "reverted",
+    });
+
+    await expect(actions.transfer({to: TO_ADDRESS, value: parseEther("1")})).rejects.toThrow(
+      /Transfer reverted/,
+    );
+  });
+
+  it("throws when no account is connected", async () => {
+    const client = {account: undefined, chain: {id: 1}} as any;
+    const publicClient = {} as any;
+    const actions = accountActions(client, publicClient);
+
+    await expect(actions.transfer({to: TO_ADDRESS, value: parseEther("1")})).rejects.toThrow(
+      /requires a local-key account/,
+    );
+  });
+
+  it("throws for Address-only (json-rpc) accounts", async () => {
+    const client = {account: {address: ACCOUNT_ADDRESS, type: "json-rpc"}, chain: {id: 1}} as any;
+    const publicClient = {} as any;
+    const actions = accountActions(client, publicClient);
+
+    await expect(actions.transfer({to: TO_ADDRESS, value: parseEther("1")})).rejects.toThrow(
+      /requires a local-key account/,
     );
   });
 });

--- a/tests/client.test-d.ts
+++ b/tests/client.test-d.ts
@@ -34,6 +34,14 @@ test("type checks", () => {
     params: [exampleAddress, "from"],
   });
 
+  void client.transfer({
+    to: exampleAddress,
+    value: 1n,
+  });
+
+  // @ts-expect-error value must be a bigint
+  void client.transfer({to: exampleAddress, value: 1});
+
   void client.getContractSchema(exampleAddress);
 
   void client.getContractSchemaForCode("class SomeContract...");

--- a/tests/staking-actions.test.ts
+++ b/tests/staking-actions.test.ts
@@ -1,0 +1,221 @@
+import {describe, expect, it, vi} from "vitest";
+import {decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAbiItem, parseEther} from "viem";
+import {STAKING_ABI, VALIDATOR_WALLET_ABI} from "../src/abi/staking";
+import {stakingActions} from "../src/staking/actions";
+
+const ACCOUNT_ADDRESS = "0x0000000000000000000000000000000000000011";
+const STAKING_ADDRESS = "0x0000000000000000000000000000000000000044";
+const VALIDATOR_WALLET_ADDRESS = "0x0000000000000000000000000000000000000099";
+const OPERATOR_ADDRESS = "0x00000000000000000000000000000000000000AA";
+const GAS_PRICE_HEX = "0x3b9aca00";
+const MOCK_TX_HASH = "0x1234000000000000000000000000000000000000000000000000000000001234";
+
+// Build a real ValidatorJoin event log so decodeEventLog resolves it exactly as
+// the SDK does on-chain (operator, validator, amount — all non-indexed).
+const validatorJoinLog = () => {
+  const topics = encodeEventTopics({abi: STAKING_ABI, eventName: "ValidatorJoin"});
+  const event = getAbiItem({abi: STAKING_ABI, name: "ValidatorJoin"}) as any;
+  const data = encodeAbiParameters(event.inputs, [OPERATOR_ADDRESS, VALIDATOR_WALLET_ADDRESS, parseEther("2")]);
+  return {data, topics, address: STAKING_ADDRESS};
+};
+
+const makeReceipt = (overrides: Record<string, unknown> = {}) => ({
+  status: "success" as const,
+  transactionHash: MOCK_TX_HASH as `0x${string}`,
+  blockNumber: 12n,
+  gasUsed: 345n,
+  logs: [validatorJoinLog()],
+  ...overrides,
+});
+
+const baseChain = {
+  id: 1,
+  name: "test",
+  nativeCurrency: {name: "GEN", symbol: "GEN", decimals: 18},
+  rpcUrls: {default: {http: ["http://127.0.0.1"]}},
+  isStudio: false,
+  stakingContract: {address: STAKING_ADDRESS},
+};
+
+// Local-key harness (byte-for-byte regression anchor for the sign+sendRaw lane).
+const makeLocalHarness = () => {
+  const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+  const client = {
+    account: {address: ACCOUNT_ADDRESS, type: "local", signTransaction},
+    chain: baseChain,
+  };
+  const publicClient = {
+    call: vi.fn().mockResolvedValue("0x"),
+    estimateGas: vi.fn().mockResolvedValue(21000n),
+    getTransactionCount: vi.fn().mockResolvedValue(7),
+    prepareTransactionRequest: vi.fn().mockImplementation(async (r: any) => r),
+    sendRawTransaction: vi.fn().mockResolvedValue(MOCK_TX_HASH),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue(makeReceipt()),
+    getTransactionReceipt: vi.fn().mockResolvedValue(makeReceipt()),
+    readContract: vi.fn(),
+  };
+  return {actions: stakingActions(client as any, publicClient as any), client, publicClient, signTransaction};
+};
+
+// Provider harness: Address-only account (type: "json-rpc"). signTransaction is
+// attached deliberately to prove the discriminator is account.type, not its presence.
+const makeProviderHarness = () => {
+  const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+  const request = vi.fn().mockImplementation(async ({method}: any) => {
+    if (method === "eth_gasPrice") return GAS_PRICE_HEX;
+    if (method === "eth_sendTransaction") return MOCK_TX_HASH;
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const client = {
+    account: {address: ACCOUNT_ADDRESS, type: "json-rpc", signTransaction},
+    chain: baseChain,
+    request,
+  };
+  const publicClient = {
+    call: vi.fn().mockResolvedValue("0x"),
+    estimateGas: vi.fn().mockResolvedValue(21000n),
+    getTransactionCount: vi.fn().mockResolvedValue(7),
+    prepareTransactionRequest: vi.fn().mockImplementation(async (r: any) => r),
+    sendRawTransaction: vi.fn().mockResolvedValue(MOCK_TX_HASH),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue(makeReceipt()),
+    getTransactionReceipt: vi.fn().mockResolvedValue(makeReceipt()),
+    readContract: vi.fn(),
+  };
+  return {actions: stakingActions(client as any, publicClient as any), client, publicClient, request, signTransaction};
+};
+
+const sentTxParams = (request: ReturnType<typeof makeProviderHarness>["request"]) => {
+  const call = request.mock.calls.find(([args]: any) => args.method === "eth_sendTransaction");
+  return call![0].params[0];
+};
+
+describe("stakingActions local lane", () => {
+  it("validatorJoin encodes the call, decodes the ValidatorJoin event, and returns the full shape", async () => {
+    const {actions, publicClient, signTransaction} = makeLocalHarness();
+
+    const result = await actions.validatorJoin({amount: "2gen", operator: OPERATOR_ADDRESS});
+
+    // Encoding routed to the staking contract with msg.value = stake amount.
+    expect(publicClient.call.mock.calls[0][0].to).toBe(STAKING_ADDRESS);
+    expect(publicClient.call.mock.calls[0][0].value).toBe(parseEther("2"));
+    expect(decodeFunctionData({abi: STAKING_ABI, data: publicClient.call.mock.calls[0][0].data})).toEqual({
+      functionName: "validatorJoin",
+      args: [OPERATOR_ADDRESS],
+    });
+
+    // Local sign+sendRaw path.
+    expect(signTransaction).toHaveBeenCalledTimes(1);
+    expect(publicClient.sendRawTransaction).toHaveBeenCalledWith({serializedTransaction: "0xsigned"});
+
+    expect(result).toEqual({
+      transactionHash: MOCK_TX_HASH,
+      blockNumber: 12n,
+      gasUsed: 345n,
+      validatorWallet: VALIDATOR_WALLET_ADDRESS,
+      operator: OPERATOR_ADDRESS,
+      amount: "2 GEN",
+      amountRaw: parseEther("2"),
+    });
+  });
+});
+
+describe("stakingActions provider lane (Address-only)", () => {
+  it("validatorDeposit (payable) routes through eth_sendTransaction with msg.value", async () => {
+    const {actions, request, publicClient, signTransaction} = makeProviderHarness();
+
+    const result = await actions.validatorDeposit({validator: VALIDATOR_WALLET_ADDRESS, amount: "5gen"});
+
+    const params = sentTxParams(request);
+    expect(params.from).toBe(ACCOUNT_ADDRESS);
+    expect(params.to).toBe(VALIDATOR_WALLET_ADDRESS);
+    expect(decodeFunctionData({abi: VALIDATOR_WALLET_ABI, data: params.data})).toEqual({
+      functionName: "validatorDeposit",
+      args: undefined,
+    });
+    expect(params.type).toBe("0x0");
+    expect(params.gas).toBe(`0x${(42000).toString(16)}`);
+    expect(params.gasPrice).toBe(GAS_PRICE_HEX);
+    // Payable: value is present as a hex quantity.
+    expect(params.value).toBe(`0x${parseEther("5").toString(16)}`);
+
+    // Local-lane primitives untouched.
+    expect(signTransaction).not.toHaveBeenCalled();
+    expect(publicClient.sendRawTransaction).not.toHaveBeenCalled();
+    expect(publicClient.getTransactionCount).not.toHaveBeenCalled();
+    expect(publicClient.prepareTransactionRequest).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      transactionHash: MOCK_TX_HASH,
+      blockNumber: 12n,
+      gasUsed: 345n,
+    });
+  });
+
+  it("delegatorExit (non-payable) routes through eth_sendTransaction with value omitted", async () => {
+    const {actions, request} = makeProviderHarness();
+
+    await actions.delegatorExit({validator: VALIDATOR_WALLET_ADDRESS, shares: "42"});
+
+    const params = sentTxParams(request);
+    expect(params.to).toBe(STAKING_ADDRESS);
+    expect(decodeFunctionData({abi: STAKING_ABI, data: params.data})).toEqual({
+      functionName: "delegatorExit",
+      args: [VALIDATOR_WALLET_ADDRESS, 42n],
+    });
+    expect(params.value).toBeUndefined();
+  });
+
+  it("validatorJoin decodes the ValidatorJoin event off the provider-returned hash", async () => {
+    const {actions, request, signTransaction} = makeProviderHarness();
+
+    const result = await actions.validatorJoin({amount: "2gen", operator: OPERATOR_ADDRESS});
+
+    // Sent via the provider lane, not signed locally.
+    expect(sentTxParams(request).to).toBe(STAKING_ADDRESS);
+    expect(signTransaction).not.toHaveBeenCalled();
+
+    // Event decode still works because the follow-up getTransactionReceipt uses
+    // the same hash the provider returned.
+    expect(result).toEqual({
+      transactionHash: MOCK_TX_HASH,
+      blockNumber: 12n,
+      gasUsed: 345n,
+      validatorWallet: VALIDATOR_WALLET_ADDRESS,
+      operator: OPERATOR_ADDRESS,
+      amount: "2 GEN",
+      amountRaw: parseEther("2"),
+    });
+  });
+
+  it("still runs the preflight and throws before sending on a would-revert", async () => {
+    const {actions, publicClient, request} = makeProviderHarness();
+    publicClient.call.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(actions.delegatorExit({validator: VALIDATOR_WALLET_ADDRESS, shares: "1"})).rejects.toThrow(
+      /Transaction would revert/,
+    );
+    expect(request).not.toHaveBeenCalledWith(expect.objectContaining({method: "eth_sendTransaction"}));
+  });
+
+  it("throws when the mined receipt is reverted", async () => {
+    const {actions, publicClient} = makeProviderHarness();
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce(makeReceipt({status: "reverted"}));
+
+    await expect(actions.delegatorExit({validator: VALIDATOR_WALLET_ADDRESS, shares: "1"})).rejects.toThrow(
+      /Transaction reverted/,
+    );
+  });
+
+  it("sends without gasPrice when eth_gasPrice rejects", async () => {
+    const {actions, request} = makeProviderHarness();
+    request.mockImplementation(async ({method}: any) => {
+      if (method === "eth_gasPrice") throw new Error("no gas price");
+      if (method === "eth_sendTransaction") return MOCK_TX_HASH;
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    await actions.delegatorExit({validator: VALIDATOR_WALLET_ADDRESS, shares: "1"});
+
+    expect(sentTxParams(request).gasPrice).toBeUndefined();
+  });
+});

--- a/tests/vesting-actions.test.ts
+++ b/tests/vesting-actions.test.ts
@@ -343,3 +343,130 @@ describe("vestingActions", () => {
     });
   });
 });
+
+// Provider lane: Address-only account (type: "json-rpc"). The connected wallet
+// manages nonce + signing, so writes route through client.request
+// eth_sendTransaction instead of the local sign+sendRaw path.
+const GAS_PRICE_HEX = "0x3b9aca00";
+
+const makeProviderHarness = () => {
+  // signTransaction is attached but MUST be ignored: the discriminator is
+  // account.type === "local", never presence of signTransaction.
+  const signTransaction = vi.fn().mockResolvedValue("0xsigned");
+  const request = vi.fn().mockImplementation(async ({method}: any) => {
+    if (method === "eth_gasPrice") return GAS_PRICE_HEX;
+    if (method === "eth_sendTransaction") return MOCK_TX_HASH;
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const client = {
+    account: {address: ACCOUNT_ADDRESS, type: "json-rpc", signTransaction},
+    chain: {
+      id: 1,
+      name: "test",
+      nativeCurrency: {name: "GEN", symbol: "GEN", decimals: 18},
+      rpcUrls: {default: {http: ["http://127.0.0.1"]}},
+      isStudio: false,
+      consensusMainContract: {address: CONSENSUS_MAIN_ADDRESS, abi: [], bytecode: "0x"},
+    },
+    request,
+  };
+  const publicClient = {
+    call: vi.fn().mockResolvedValue("0x"),
+    estimateGas: vi.fn().mockResolvedValue(21000n),
+    getTransactionCount: vi.fn().mockResolvedValue(7),
+    prepareTransactionRequest: vi.fn().mockImplementation(async (r: any) => r),
+    sendRawTransaction: vi.fn().mockResolvedValue(MOCK_TX_HASH),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue(makeReceipt()),
+    readContract: vi.fn(),
+  };
+
+  return {
+    actions: vestingActions(client as any, publicClient as any),
+    client,
+    publicClient,
+    request,
+    signTransaction,
+  };
+};
+
+const sentTxParams = (request: ReturnType<typeof makeProviderHarness>["request"]) => {
+  const call = request.mock.calls.find(([args]: any) => args.method === "eth_sendTransaction");
+  return call![0].params[0];
+};
+
+describe("vestingActions provider lane (Address-only)", () => {
+  it("routes writes through eth_sendTransaction with the expected params", async () => {
+    const {actions, request, publicClient, signTransaction} = makeProviderHarness();
+
+    await actions.vestingDelegatorExit({vesting: VESTING_ADDRESS, validator: VALIDATOR_ADDRESS, shares: "42"});
+
+    const params = sentTxParams(request);
+    expect(params.from).toBe(ACCOUNT_ADDRESS);
+    expect(params.to).toBe(VESTING_ADDRESS);
+    expect(decodeFunctionData({abi: VESTING_ABI, data: params.data})).toEqual({
+      functionName: "vestingDelegatorExit",
+      args: [VALIDATOR_ADDRESS, 42n],
+    });
+    expect(params.type).toBe("0x0");
+    // gasLimit = estimateGas(21000) * 2 buffer = 42000 = 0xa410
+    expect(params.gas).toBe(`0x${(42000).toString(16)}`);
+    expect(params.gasPrice).toBe(GAS_PRICE_HEX);
+    // Vesting writes carry no msg.value (amounts are ABI args), so value is omitted.
+    expect(params.value).toBeUndefined();
+
+    // Local-lane primitives must NOT be touched on the provider path.
+    expect(signTransaction).not.toHaveBeenCalled();
+    expect(publicClient.sendRawTransaction).not.toHaveBeenCalled();
+    expect(publicClient.getTransactionCount).not.toHaveBeenCalled();
+    expect(publicClient.prepareTransactionRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns the same receipt-derived shape as the local lane", async () => {
+    const {actions} = makeProviderHarness();
+
+    const result = await actions.vestingWithdraw({vesting: VESTING_ADDRESS, amount: "1gen"});
+
+    expect(result).toMatchObject({
+      transactionHash: MOCK_TX_HASH,
+      blockNumber: 12n,
+      gasUsed: 345n,
+      vesting: VESTING_ADDRESS,
+      beneficiary: ACCOUNT_ADDRESS,
+      amount: "1 GEN",
+      amountRaw: parseEther("1"),
+    });
+  });
+
+  it("still runs the preflight and throws before sending on a would-revert", async () => {
+    const {actions, publicClient, request} = makeProviderHarness();
+    publicClient.call.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(
+      actions.vestingDelegatorClaim({vesting: VESTING_ADDRESS, validator: VALIDATOR_ADDRESS}),
+    ).rejects.toThrow(/Transaction would revert/);
+
+    expect(request).not.toHaveBeenCalledWith(expect.objectContaining({method: "eth_sendTransaction"}));
+  });
+
+  it("throws when the mined receipt is reverted", async () => {
+    const {actions, publicClient} = makeProviderHarness();
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({...makeReceipt(), status: "reverted"});
+
+    await expect(
+      actions.vestingDelegatorClaim({vesting: VESTING_ADDRESS, validator: VALIDATOR_ADDRESS}),
+    ).rejects.toThrow(/Transaction reverted/);
+  });
+
+  it("sends without gasPrice when eth_gasPrice rejects", async () => {
+    const {actions, request} = makeProviderHarness();
+    request.mockImplementation(async ({method}: any) => {
+      if (method === "eth_gasPrice") throw new Error("no gas price");
+      if (method === "eth_sendTransaction") return MOCK_TX_HASH;
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    await actions.vestingDelegatorClaim({vesting: VESTING_ADDRESS, validator: VALIDATOR_ADDRESS});
+
+    expect(sentTxParams(request).gasPrice).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two SDK changes on the shared write core. The local-key path is unchanged and remains the regression gate.

### B1 — provider-aware `executeWrite` (staking + vesting)
`executeWrite` in `src/staking/actions.ts` and `src/vesting/actions.ts` now branches on `account.type === "local"`:
- **local**: unchanged statements (`getTransactionCount` -> `prepareTransactionRequest{type:"legacy"}` -> `signTransaction` guard -> sign -> `sendRawTransaction`), moved verbatim inside the `if`.
- **else (Address-only / provider)**: best-effort `eth_gasPrice` then `client.request({method:"eth_sendTransaction", ...})` with `type:"0x0"`, wallet manages the nonce. Mirrors the proven IC provider lane in `src/contracts/actions.ts` (~:2169-2178 / :2412-2422).

Shared preflight simulate + gas estimate stay before the branch; the `publicClient.waitForTransactionReceipt` wait, revert diagnostics, and returned `{transactionHash, blockNumber, gasUsed}` shape are unchanged. Discriminator is strictly `account.type === "local"` (inner `signTransaction` guard retained). No `src/types/*` write-path changes.

### B2 — native `transfer` action
`src/accounts/actions.ts`: factory is now `accountActions(client, publicClient)` and exposes `transfer({to, value}): Promise<TransactionReceipt>` — local-key only (throws a clear "requires a local-key account" error for missing / non-local / Address-only accounts). Mirrors the `executeWrite` local lane 1:1. Plumbed in `src/client/client.ts` (passes the in-scope `publicClient`) and typed in `src/types/clients.ts`.

## Testing
- `npm run build` (incl. DTS) green; `npm run lint` clean.
- `npm test` (`vitest --typecheck`): 115 passed / 8 files (was 98 / 7). Existing local-lane write tests unchanged.
- New: `tests/staking-actions.test.ts` (local `validatorJoin` anchor + provider `validatorDeposit`/`delegatorExit`/`validatorJoin` event-decode); provider-lane `describe` in `tests/vesting-actions.test.ts`; `transfer` cases in `tests/accounts-actions.test.ts`; `transfer` type assertion in `tests/client.test-d.ts`.

Unblocks CLI browser-wallet writes routing through the SDK.

> Note: the existing `getCurrentNonce` invocations in `tests/accounts-actions.test.ts` gained a second `publicClient` argument — an unavoidable consequence of the mandated `accountActions(client, publicClient)` signature change, not a write-path regression edit.

**Do not merge** — shared write core; human review before it lands on `v2-dev`.