### PR TITLE
fix: resolve triggered transaction IDs from decision receipts

### DIFF
--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -189,22 +189,51 @@ export const transactionActions = (client: GenLayerClient<GenLayerChain>, public
     const proposalBlock = BigInt(tx.readStateBlockRange?.proposalBlock ?? "0");
     if (proposalBlock === BigInt(0)) return [];
 
-    const scanRange = BigInt(100);
+    const scanRange = BigInt(10_000);
     const latestBlock = await publicClient.getBlockNumber();
     const toBlock = proposalBlock + scanRange < latestBlock ? proposalBlock + scanRange : latestBlock;
 
     const consensusAddress = client.chain.consensusMainContract?.address as Address;
     const internalMessageProcessedTopic = keccak256(stringToBytes("InternalMessageProcessed(bytes32,address,address)"));
+    const transactionAcceptedTopic = keccak256(stringToBytes("TransactionAccepted(bytes32)"));
+    const transactionFinalizedTopic = keccak256(stringToBytes("TransactionFinalized(bytes32)"));
 
-    const logs = await publicClient.getLogs({
+    // InternalMessageProcessed indexes the child transaction ID, not its
+    // parent. Find the EVM transactions that decided the parent first, then
+    // inspect their receipts for the child-message events emitted alongside
+    // that decision.
+    const decisionLogs = await publicClient.getLogs({
       address: consensusAddress,
       event: undefined,
       fromBlock: proposalBlock,
       toBlock,
-      topics: [internalMessageProcessedTopic, hash],
+      topics: [[transactionAcceptedTopic, transactionFinalizedTopic], hash],
     } as any);
 
-    return logs.map(log => log.topics[1] as TransactionHash).filter(Boolean);
+    const decisionTransactionHashes = [
+      ...new Set(decisionLogs.map(log => log.transactionHash).filter(Boolean)),
+    ];
+    const receipts = await Promise.all(
+      decisionTransactionHashes.map(transactionHash =>
+        publicClient.getTransactionReceipt({hash: transactionHash!}),
+      ),
+    );
+    const normalizedConsensusAddress = consensusAddress.toLowerCase();
+
+    return [
+      ...new Set(
+        receipts.flatMap(receipt =>
+          receipt.logs
+            .filter(
+              log =>
+                log.address.toLowerCase() === normalizedConsensusAddress &&
+                log.topics[0] === internalMessageProcessedTopic,
+            )
+            .map(log => log.topics[1] as TransactionHash)
+            .filter(Boolean),
+        ),
+      ),
+    ];
   },
   /** Fetches the full execution trace including return data, stdout, stderr, and GenVM logs. */
   debugTraceTransaction: async ({hash, round = 0}: {hash: TransactionHash; round?: number}): Promise<DebugTraceResult> => {

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -13,6 +13,7 @@ import { receiptActions, transactionActions, isSuccessful } from "../src/transac
 import { decodeTransaction, simplifyTransactionReceipt } from "../src/transactions/decoders";
 import { localnet } from "../src/chains/localnet";
 import type { GenLayerRawTransaction } from "../src/types/transactions";
+import {keccak256, stringToBytes} from "viem";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -357,6 +358,53 @@ const makeRawTx = (overrides: Record<string, unknown> = {}): GenLayerRawTransact
     validatorVotes: [1, 1, 1],
   },
   ...overrides,
+});
+
+describe("getTriggeredTransactionIds", () => {
+  it("finds child transaction IDs in the parent decision receipt", async () => {
+    const parentHash = ("0x" + "11".repeat(32)) as any;
+    const childHash = ("0x" + "22".repeat(32)) as any;
+    const decisionHash = ("0x" + "33".repeat(32)) as any;
+    const consensusAddress = "0x0000000000000000000000000000000000000010";
+    const internalMessageTopic = keccak256(
+      stringToBytes("InternalMessageProcessed(bytes32,address,address)"),
+    );
+    const readContract = vi
+      .fn()
+      .mockResolvedValueOnce(makeRawTx({readStateBlockRange: {proposalBlock: 100n}}))
+      .mockResolvedValueOnce([{txExecutionResult: 1n}, []]);
+    const getLogs = vi.fn().mockResolvedValue([{transactionHash: decisionHash}]);
+    const getTransactionReceipt = vi.fn().mockResolvedValue({
+      logs: [
+        {
+          address: consensusAddress,
+          topics: [internalMessageTopic, childHash],
+        },
+      ],
+    });
+    const publicClient = {
+      readContract,
+      getBlockNumber: vi.fn().mockResolvedValue(200n),
+      getLogs,
+      getTransactionReceipt,
+    } as any;
+    const client = {
+      chain: {
+        isStudio: false,
+        consensusDataContract: {address: consensusAddress, abi: []},
+        consensusMainContract: {address: consensusAddress, abi: []},
+      },
+    } as any;
+
+    const result = await transactionActions(client, publicClient).getTriggeredTransactionIds({
+      hash: parentHash,
+    });
+
+    expect(result).toEqual([childHash]);
+    expect(getLogs.mock.calls[0][0].topics[1]).toBe(parentHash);
+    expect(Array.isArray(getLogs.mock.calls[0][0].topics[0])).toBe(true);
+    expect(getTransactionReceipt).toHaveBeenCalledWith({hash: decisionHash});
+  });
 });
 
 describe("decodeTransaction", () => {


### PR DESCRIPTION
## Summary
- locate parent acceptance/finalization transactions before reading child-message events
- inspect decision receipts and deduplicate triggered transaction IDs
- add a regression test for parent/child topic separation

## Verification
- `npm test -- --run` (119 tests, typecheck clean)
- focused ESLint check