### PR TITLE
fix(docs): repair broken Discord badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GenLayerJS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/license/mit/)
-[![Discord](https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat)](https://discord.gg/VpfmXEMN66)
+[![Discord](https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat)](https://discord.gg/VpfmXEMN66)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/genlaboratory.svg?style=social&label=Follow%20%40GenLayer)](https://x.com/GenLayer)
 [![GitHub star chart](https://img.shields.io/github/stars/genlayerlabs/genlayer-js?style=social)](https://star-history.com/#genlayerlabs/genlayer-js)
 


### PR DESCRIPTION
## Problem

The Discord badge points at **`dcbadge.vercel.app`**, which no longer serves badges — the request returns **HTTP 404**, so the badge renders as a broken image:

```
404  https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat
```

The project moved to **`dcbadge.limes.pink`**, which keeps the exact same API path and query parameters:

```
200  https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat
```

(The old host answers 404 to any user agent; the new host returns 200 — it does reject some non-browser agents with 403, which is why a naive checker can miss it.)

## Fix

Swap the host, nothing else — same path, same query string, so the badge renders exactly as before:

```diff
-[![Discord](https://dcbadge.vercel.app/api/server/8Jm4v89VAu?compact=true&style=flat)](...)
+[![Discord](https://dcbadge.limes.pink/api/server/8Jm4v89VAu?compact=true&style=flat)](...)
```

The Discord invite link itself is untouched.

Docs-only, one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Discord badge image used in the README.
  * The existing Discord link remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->