### PR TITLE
feat: add explicit gas override to writeContract/deployContract

### DIFF
--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -356,6 +356,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      gas?: bigint;
     }): Promise<`0x${string}`> => {
       const {
         account,
@@ -368,6 +369,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
         validUntil,
         fees,
+        gas,
       } = args;
 
       const data = [calldata.encode(calldata.makeCalldataObject(functionName, callArgs, kwargs)), leaderOnly];
@@ -394,6 +396,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         publicClient,
         transactionVariants,
         senderAccount,
+        gas,
       });
     },
     /** Deploys a new intelligent contract to GenLayer. Returns the transaction hash. */
@@ -406,6 +409,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      gas?: bigint;
     }) => {
       const {
         account,
@@ -416,6 +420,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
         validUntil,
         fees,
+        gas,
       } = args;
 
       const data = [
@@ -446,6 +451,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         publicClient,
         transactionVariants,
         senderAccount,
+        gas,
       });
     },
     /** Returns the active fee price policy used to build user-side caps. */
@@ -1988,11 +1994,18 @@ const _sendTransaction = async ({
   publicClient,
   transactionVariants,
   senderAccount,
+  gas: gasOverride,
 }: {
   client: GenLayerClient<GenLayerChain>;
   publicClient: PublicClient;
   transactionVariants: EncodedTransactionVariant[];
   senderAccount?: Account;
+  /**
+   * Explicit outer EVM gas limit, bypassing `eth_estimateGas` and the
+   * automatic headroom below. Used as-is with no further markup, since an
+   * explicit override is the caller stating what to use.
+   */
+  gas?: bigint;
 }) => {
   if (!client.chain.consensusMainContract?.address) {
     throw new Error(`Consensus main contract address not found in chain config for "${client.chain.name}".`);
@@ -2046,18 +2059,22 @@ const _sendTransaction = async ({
   const sendWithEncodedData = async (transactionVariant: EncodedTransactionVariant) => {
     let estimatedGas: bigint;
     let gasEstimationError: string | undefined;
-    try {
-      estimatedGas = await client.estimateTransactionGas({
-        from: validatedSenderAccount.address,
-        to: client.chain.consensusMainContract?.address as Address,
-        data: transactionVariant.encodedData,
-        value: transactionVariant.value,
-      });
-      estimatedGas = withTransactionGasHeadroom(estimatedGas);
-    } catch (err) {
-      gasEstimationError = stringifyRpcError(err);
-      console.error("Gas estimation failed, using default 200_000:", err);
-      estimatedGas = 200_000n;
+    if (gasOverride !== undefined) {
+      estimatedGas = gasOverride;
+    } else {
+      try {
+        estimatedGas = await client.estimateTransactionGas({
+          from: validatedSenderAccount.address,
+          to: client.chain.consensusMainContract?.address as Address,
+          data: transactionVariant.encodedData,
+          value: transactionVariant.value,
+        });
+        estimatedGas = withTransactionGasHeadroom(estimatedGas);
+      } catch (err) {
+        gasEstimationError = stringifyRpcError(err);
+        console.error("Gas estimation failed, using default 200_000:", err);
+        estimatedGas = 200_000n;
+      }
     }
 
     // For local accounts, build transaction request directly to avoid viem's

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -2013,6 +2013,9 @@ const _sendTransaction = async ({
   if (transactionVariants.length === 0) {
     throw new Error("No transaction variants available to send.");
   }
+  if (gasOverride !== undefined && gasOverride <= 0n) {
+    throw new Error("gas must be greater than zero.");
+  }
 
   const validatedSenderAccount = validateAccount(senderAccount);
   const nonce = await client.getCurrentNonce({address: validatedSenderAccount.address});

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -82,6 +82,14 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      /**
+       * Explicit outer EVM gas limit for the `addTransaction` call, bypassing
+       * `eth_estimateGas` and the automatic safety headroom entirely. Useful
+       * when gas estimation is unreliable for a given RPC/network and the
+       * estimated-but-exact limit reverts the outer transaction before GenVM
+       * even sees it.
+       */
+      gas?: bigint;
     }) => Promise<any>;
     simulateWriteContract: <
       RawReturn extends boolean | undefined = undefined,
@@ -110,6 +118,8 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      /** Explicit outer EVM gas limit, bypassing `eth_estimateGas`. See `writeContract`'s `gas` option. */
+      gas?: bigint;
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: Address}) => Promise<number>;

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -461,6 +461,76 @@ describe("contractActions addTransaction ABI compatibility", () => {
     expect(encodedData.slice(0, 10)).toBe(selectorForV5);
   });
 
+  it("uses the explicit gas override as-is, bypassing eth_estimateGas entirely (#402)", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 0n,
+        gas: 2_000_000n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    // eth_estimateGas must not be called at all when an override is supplied —
+    // an exact estimate is exactly the failure mode #402 reports, so the
+    // override path must not go anywhere near it.
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+
+    const txRequest = signTransaction.mock.calls[0][0];
+    expect(txRequest.gas).toBe(2_000_000n);
+  });
+
+  it("still estimates and applies headroom when no gas override is given (#402)", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+    estimateTransactionGas.mockResolvedValue(1_319_997n);
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 0n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(estimateTransactionGas).toHaveBeenCalledTimes(1);
+
+    const txRequest = signTransaction.mock.calls[0][0];
+    // 1_319_997 * 20_000bps / 10_000 = 2_639_994 — well above the 2_000_000
+    // that #402 confirmed succeeds against the exact 1_319_997 estimate that
+    // reverted twice.
+    expect(txRequest.gas).toBe(2_639_994n);
+  });
+
+  it("threads the gas override through deployContract the same way as writeContract (#402)", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.deployContract({
+        code: "0x1234",
+        args: [],
+        gas: 3_000_000n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    const txRequest = signTransaction.mock.calls[0][0];
+    expect(txRequest.gas).toBe(3_000_000n);
+  });
+
   it("encodes addTransaction with 6 args when ABI has 6 inputs", async () => {
     const {actions, estimateTransactionGas} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_V6,

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -486,6 +486,46 @@ describe("contractActions addTransaction ABI compatibility", () => {
     expect(txRequest.gas).toBe(2_000_000n);
   });
 
+  it("rejects a zero gas override before any transaction preparation", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 0n,
+        gas: 0n,
+      }),
+    ).rejects.toThrow("gas must be greater than zero.");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects a negative gas override before any transaction preparation", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 0n,
+        gas: -1n,
+      }),
+    ).rejects.toThrow("gas must be greater than zero.");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
   it("still estimates and applies headroom when no gas override is given (#402)", async () => {
     const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
     const {actions, estimateTransactionGas} = setupWriteContractHarness({


### PR DESCRIPTION
## Summary

Adds the second part of #402's ask: an explicit `gas` override for `writeContract`/`deployContract`, bypassing `eth_estimateGas` entirely.

## Context

#402 reports that an *exact* `eth_estimateGas` result was used as the outer EVM gas limit on Bradbury, and the resulting transaction reverted twice — identical calldata succeeded when replayed with a larger explicit limit. No way existed to override the estimate.

**On the automatic-headroom part of the ask:** this repo already has `withTransactionGasHeadroom` (a 2x margin over the estimate), which would cover the exact numbers in #402's repro (1,319,997 estimated → 2,639,994 with headroom, comfortably above the 2,000,000 that #402 confirmed works). I checked the actual `genlayer-js@1.1.8` tarball from the npm registry directly and confirmed this headroom code isn't in the published package yet — so that part of the fix exists but hasn't shipped. This PR is the complementary, still-needed part: a caller-side override for cases even the headroom doesn't cover, or for callers who just want deterministic control over gas.

## Change

Added an optional `gas?: bigint` to `writeContract` and `deployContract`'s options. When provided:
- `eth_estimateGas` is not called at all
- no headroom markup is applied
- the value is used exactly as given, on both the local-account (`signTransaction`) and external-wallet (`eth_sendTransaction`) send paths

Both functions already funnel through a shared `_sendTransaction` → `sendWithEncodedData` helper, so this was a single plumbing point for both.

## Testing

Added 4 cases to `tests/contracts-actions.test.ts`, reusing the existing `setupWriteContractHarness`:
- explicit override bypasses `eth_estimateGas` entirely and is used as-is
- omitting the override still estimates and applies headroom — asserts the exact `2_639_994n` value from #402's own numbers (`1_319_997 * 20_000bps / 10_000`)
- the override threads through `deployContract` the same way as `writeContract`

Full suite: 87 passed. `eslint`: clean on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional gas limit overrides for contract write and deployment transactions.
  * Transactions with an explicit gas limit skip automatic gas estimation.
  * Existing automatic estimation and safety headroom remain unchanged when no override is provided.

* **Tests**
  * Added coverage confirming explicit gas limits are preserved and default estimation continues to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->