### PR TITLE
fix(calldata): align toString output with the reference format

### DIFF
--- a/src/abi/calldata/string.ts
+++ b/src/abi/calldata/string.ts
@@ -7,7 +7,12 @@ function reportError(msg: string, data: CalldataEncodable): never {
 
 function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
     to.push("{");
+    let first = true;
     for (const [k, v] of data) {
+      if (!first) {
+        to.push(",");
+      }
+      first = false;
       to.push(JSON.stringify(k));
       to.push(":");
       toStringImpl(v, to);
@@ -48,13 +53,17 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         if (data instanceof Uint8Array) {
           to.push("b#");
           for (const b of data) {
-            to.push(b.toString(16));
+            to.push(b.toString(16).padStart(2, "0"));
           }
         } else if (data instanceof Array) {
           to.push("[");
+          let first = true;
           for (const c of data) {
+            if (!first) {
+              to.push(",");
+            }
+            first = false;
             toStringImpl(c, to);
-            to.push(",");
           }
           to.push("]");
         } else if (data instanceof Map) {
@@ -62,7 +71,7 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         } else if (data instanceof CalldataAddress) {
           to.push("addr#");
           for (const c of data.bytes) {
-            to.push(c.toString(16));
+            to.push(c.toString(16).padStart(2, "0"));
           }
         } else if (Object.getPrototypeOf(data) === Object.prototype) {
           toStringImplMap(Object.entries(data), to);

--- a/tests/calldata-to-string.test.ts
+++ b/tests/calldata-to-string.test.ts
@@ -1,0 +1,41 @@
+import {describe, it, expect} from "vitest";
+import * as calldata from "@/abi/calldata";
+import {CalldataAddress} from "@/types/calldata";
+
+// Expected output matches the reference implementation in the genvm repo
+// (runners/genlayer-py-std/src/genlayer/calldata/__init__.py :: to_str)
+
+describe("calldata.toString", () => {
+  it("encodes bytes as zero-padded hex", () => {
+    expect(calldata.toString(new Uint8Array([0xab, 0xcd]))).toBe("b#abcd");
+    expect(calldata.toString(new Uint8Array([0x01, 0x02]))).toBe("b#0102");
+    expect(calldata.toString(new Uint8Array([0xff]))).toBe("b#ff");
+  });
+
+  it("does not collapse distinct byte arrays into the same string", () => {
+    const a = calldata.toString(new Uint8Array([0x01, 0x02]));
+    const b = calldata.toString(new Uint8Array([0x12]));
+    expect(a).not.toBe(b);
+  });
+
+  it("encodes an address as 40 hex characters", () => {
+    const addr = new CalldataAddress(new Uint8Array(20).fill(0x01));
+    expect(calldata.toString(addr)).toBe("addr#" + "01".repeat(20));
+  });
+
+  it("separates map entries with commas", () => {
+    expect(calldata.toString({a: 1})).toBe('{"a":1}');
+    expect(calldata.toString({x: true, y: null})).toBe('{"x":true,"y":null}');
+    expect(calldata.toString({})).toBe("{}");
+  });
+
+  it("separates array items with commas and emits no trailing comma", () => {
+    expect(calldata.toString([1, 2, 3])).toBe("[1,2,3]");
+    expect(calldata.toString([])).toBe("[]");
+    expect(calldata.toString([[1], [2, 3]])).toBe("[[1],[2,3]]");
+  });
+
+  it("handles nesting", () => {
+    expect(calldata.toString({items: [1, "two", null]})).toBe('{"items":[1,"two",null]}');
+  });
+});


### PR DESCRIPTION
Fixes #210

# What

Fixes three defects in `abi.calldata.toString()` (`src/abi/calldata/string.ts`):

- Bytes and addresses are now zero padded to two hex digits per byte
- Map entries are now separated by commas
- Arrays no longer emit a trailing comma

Adds `tests/calldata-to-string.test.ts`, mirroring the reference test suite at `runners/genlayer-py-std/tests/test_calldata_to_str.py` in the genvm repo.

# Why

The output did not match the reference implementation (`runners/genlayer-py-std/src/genlayer/calldata/__init__.py`, `to_str`):

| Input | before | reference |
|---|---|---|
| `new Uint8Array([0x01, 0x02])` | `b#12` | `b#0102` |
| 20-byte address of `0x01` | `addr#11111111111111111111` | 40 hex chars |
| `{x: true, y: null}` | `{"x":true"y":null}` | `{"x":true,"y":null}` |
| `[1, 2, 3]` | `[1,2,3,]` | `[1,2,3]` |

The missing hex padding is lossy rather than cosmetic: `Uint8Array([0x01, 0x02])` and `Uint8Array([0x12])` both rendered as `b#12`, so distinct values collapsed to the same string. Addresses rendered shorter than 40 characters whenever a byte was below `0x10`.

This is public API and also feeds the `readable` field of `decodeTransaction` / `simplifyTransactionReceipt` via `calldataToUserFriendlyJson`, so the malformed output was user visible.

# Testing done

- Added 6 tests covering bytes, addresses, maps, arrays, nesting, and the byte-array collision case. All fail on `v1` before the fix and pass after.
- Full suite: `npx vitest run --typecheck` gives 82 passed, no type errors. Baseline before the change was 76 passed, so no regressions.
- `npx eslint src/abi/calldata/string.ts tests/calldata-to-string.test.ts` is clean.

# Decisions made

- Expected values were taken from the genvm reference rather than invented, so the SDK matches genlayer-py output.
- `src/abi/calldata/string.ts` does not satisfy `prettier --check` on `v1` today, before this change. I left the formatting untouched so the diff stays reviewable. Happy to add a separate formatting commit if you'd prefer.
- Targeting `v1` per CONTRIBUTING, since this is a bug fix. The same defects are present on `v2`, `v2-dev` and `main`; let me know if you want a companion PR.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

The diff is 15 lines in `string.ts`. The comma changes follow the same `first` flag pattern the reference uses. The two `padStart(2, "0")` calls are the lossy part worth checking first.

# User facing release notes

`abi.calldata.toString()` now produces output matching the GenVM reference format. Byte and address values are zero padded, map entries are comma separated, and arrays no longer include a trailing comma. This also affects the `readable` field returned by `decodeTransaction` and `simplifyTransactionReceipt`.
