### PR TITLE
fix: correct four defects in calldata toString

### DIFF
--- a/src/abi/calldata/string.ts
+++ b/src/abi/calldata/string.ts
@@ -7,7 +7,10 @@ function reportError(msg: string, data: CalldataEncodable): never {
 
 function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
     to.push("{");
+    let first = true;
     for (const [k, v] of data) {
+      if (!first) to.push(",");
+      first = false;
       to.push(JSON.stringify(k));
       to.push(":");
       toStringImpl(v, to);
@@ -48,13 +51,15 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         if (data instanceof Uint8Array) {
           to.push("b#");
           for (const b of data) {
-            to.push(b.toString(16));
+            to.push(b.toString(16).padStart(2, "0"));
           }
         } else if (data instanceof Array) {
           to.push("[");
+          let first = true;
           for (const c of data) {
+            if (!first) to.push(",");
+            first = false;
             toStringImpl(c, to);
-            to.push(",");
           }
           to.push("]");
         } else if (data instanceof Map) {
@@ -62,7 +67,7 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         } else if (data instanceof CalldataAddress) {
           to.push("addr#");
           for (const c of data.bytes) {
-            to.push(c.toString(16));
+            to.push(c.toString(16).padStart(2, "0"));
           }
         } else if (Object.getPrototypeOf(data) === Object.prototype) {
           toStringImplMap(Object.entries(data), to);

--- a/tests/calldata-tostring.test.ts
+++ b/tests/calldata-tostring.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { toString } from "../src/abi/calldata/string";
+import { CalldataAddress } from "../src/types/calldata";
+
+describe("calldata toString", () => {
+  it("zero-pads bytes hex", () => {
+    expect(toString(new Uint8Array([0x01, 0x02]))).toBe("b#0102");
+  });
+
+  it("does not confuse [0x01, 0x02] with [0x12]", () => {
+    expect(toString(new Uint8Array([0x01, 0x02]))).not.toBe(toString(new Uint8Array([0x12])));
+  });
+
+  it("zero-pads address bytes to 40 hex chars", () => {
+    const bytes = new Uint8Array(20).fill(0x01);
+    expect(toString(new CalldataAddress(bytes))).toBe("addr#" + "01".repeat(20));
+  });
+
+  it("no trailing comma in arrays", () => {
+    expect(toString([1, 2, 3])).toBe("[1,2,3]");
+  });
+
+  it("comma separates map entries", () => {
+    expect(toString({ x: true, y: null })).toBe('{"x":true,"y":null}');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes four defects in `abi.calldata.toString()` to match the reference implementation in `genlayer-py-std/src/genlayer/calldata/__init__.py`.

## Defects Fixed

| Input | Before | After (Reference) |
|---|---|---|
| `new Uint8Array([0x01, 0x02])` | `b#12` | `b#0102` |
| 20-byte address of `0x01` | `addr#11111111111111111111` | `addr#0101…0101` (40 chars) |
| `{x: true, y: null}` | `{"x":true"y":null}` | `{"x":true,"y":null}` |
| `[1, 2, 3]` | `[1,2,3,]` | `[1,2,3]` |

1. **Hex zero-padding** — `b.toString(16).padStart(2, "0")` for both bytes and address bytes. Without this, `Uint8Array([0x01, 0x02])` and `Uint8Array([0x12])` both rendered as `b#12` (lossy collision).
2. **Map comma separator** — entries now emit a comma between them, making output parseable.
3. **Array trailing comma removed** — matches the reference `to_str`.

## Tests

All 5 new tests pass:
```
✓ zero-pads bytes hex
✓ does not confuse [0x01, 0x02] with [0x12]
✓ zero-pads address bytes to 40 hex chars
✓ no trailing comma in arrays
✓ comma separates map entries
```

Fixes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calldata serialization for arrays, maps, byte values, and addresses.
  * Byte values now use consistent two-digit hexadecimal formatting.
  * Arrays no longer include an unnecessary trailing comma.
  * Address values are serialized with properly padded hexadecimal output.

* **Tests**
  * Added coverage for byte arrays, addresses, arrays, and map serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->