### PR TITLE
feat: expose gas overrides for intelligent contract transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ const receipt = await client.waitForTransactionReceipt({
 
 ```
 
+`writeContract` and `deployContract` accept the same top-level `gas` override as
+viem's `sendTransaction`. It controls only the outer EVM transaction that calls
+`ConsensusMain.addTransaction`; GenLayer consensus and execution budgets remain
+under `fees`.
+
+```typescript
+const txHash = await client.deployContract({
+  account,
+  code: contractCode,
+  gas: 1_000_000n,
+});
+```
+
+When `gas` is omitted, the SDK estimates the outer EVM gas and applies safety
+headroom. If estimation fails, the SDK does not broadcast with a guessed limit;
+inspect the revert or retry with an explicit `gas` value.
+
 ### Fee presets for transactions
 
 Apps can build a trusted fee preset once they know the transaction shape, then

--- a/docs/api-references/index.md
+++ b/docs/api-references/index.md
@@ -103,6 +103,12 @@ const receipt = await client.waitForTransactionReceipt({
 
 ```
 
+`writeContract` and `deployContract` accept an optional top-level `gas` value.
+It is the gas limit for the outer EVM `addTransaction` call and is separate from
+the GenLayer protocol budgets supplied through `fees`. Without an override, the
+SDK estimates this gas and applies safety headroom; an estimation failure stops
+before broadcast instead of using a guessed fallback.
+
 ### Checking execution results
 
 A transaction can be finalized by consensus but still have a failed execution. Always check `txExecutionResult` before reading contract state:

--- a/src/contracts/actions.ts
+++ b/src/contracts/actions.ts
@@ -358,6 +358,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      gas?: bigint;
     }): Promise<`0x${string}`> => {
       const {
         account,
@@ -370,6 +371,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
         validUntil,
         fees,
+        gas,
       } = args;
 
       const data = [calldata.encode(calldata.makeCalldataObject(functionName, callArgs, kwargs)), leaderOnly];
@@ -396,6 +398,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         publicClient,
         transactionVariants,
         senderAccount,
+        gas,
       });
     },
     /** Deploys a new intelligent contract to GenLayer. Returns the transaction hash. */
@@ -408,6 +411,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      gas?: bigint;
     }) => {
       const {
         account,
@@ -418,6 +422,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         consensusMaxRotations = client.chain.defaultConsensusMaxRotations,
         validUntil,
         fees,
+        gas,
       } = args;
 
       const data = [
@@ -448,6 +453,7 @@ export const contractActions = (client: GenLayerClient<GenLayerChain>, publicCli
         publicClient,
         transactionVariants,
         senderAccount,
+        gas,
       });
     },
     /** Returns the active fee price policy used to build user-side caps. */
@@ -2262,17 +2268,23 @@ const _sendTransaction = async ({
   publicClient,
   transactionVariants,
   senderAccount,
+  gas,
 }: {
   client: GenLayerClient<GenLayerChain>;
   publicClient: PublicClient;
   transactionVariants: EncodedTransactionVariant[];
   senderAccount?: Account;
+  /** Explicit gas limit for the outer EVM `addTransaction` call. */
+  gas?: bigint;
 }) => {
   if (!client.chain.consensusMainContract?.address) {
     throw new Error(`Consensus main contract address not found in chain config for "${client.chain.name}".`);
   }
   if (transactionVariants.length === 0) {
     throw new Error("No transaction variants available to send.");
+  }
+  if (gas !== undefined && gas <= 0n) {
+    throw new Error("gas must be a positive bigint.");
   }
 
   const validatedSenderAccount = validateAccount(senderAccount);
@@ -2318,20 +2330,26 @@ const _sendTransaction = async ({
   };
 
   const sendWithEncodedData = async (transactionVariant: EncodedTransactionVariant) => {
-    let estimatedGas: bigint;
-    let gasEstimationError: string | undefined;
-    try {
-      estimatedGas = await client.estimateTransactionGas({
-        from: validatedSenderAccount.address,
-        to: client.chain.consensusMainContract?.address as Address,
-        data: transactionVariant.encodedData,
-        value: transactionVariant.value,
-      });
-      estimatedGas = withTransactionGasHeadroom(estimatedGas);
-    } catch (err) {
-      gasEstimationError = stringifyRpcError(err);
-      console.error("Gas estimation failed, using default 200_000:", err);
-      estimatedGas = 200_000n;
+    let transactionGas = gas;
+    if (transactionGas === undefined) {
+      try {
+        transactionGas = withTransactionGasHeadroom(
+          await client.estimateTransactionGas({
+            from: validatedSenderAccount.address,
+            to: client.chain.consensusMainContract?.address as Address,
+            data: transactionVariant.encodedData,
+            value: transactionVariant.value,
+          }),
+        );
+      } catch (err) {
+        const estimationError = stringifyRpcError(err);
+        throw new Error(
+          "Gas estimation failed for the outer EVM transaction; no transaction was sent. " +
+          "Inspect the revert and, if estimation is unreliable, retry with an explicit gas value." +
+          (estimationError ? ` Original error: ${estimationError}` : ""),
+          {cause: err},
+        );
+      }
     }
 
     // For local accounts, build transaction request directly to avoid viem's
@@ -2352,7 +2370,7 @@ const _sendTransaction = async ({
         type: "legacy" as const,
         nonce: Number(nonce),
         value: transactionVariant.value,
-        gas: estimatedGas,
+        gas: transactionGas,
         gasPrice: BigInt(gasPriceHex),
         chainId: client.chain.id,
       };
@@ -2371,9 +2389,7 @@ const _sendTransaction = async ({
 
       if (receipt.status === "reverted") {
         throw new Error(
-          `Transaction reverted: EVM tx ${txHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.${
-            gasEstimationError ? ` Gas estimation error: ${gasEstimationError}` : ""
-          }`,
+          `Transaction reverted: EVM tx ${txHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.`,
         );
       }
 
@@ -2414,7 +2430,7 @@ const _sendTransaction = async ({
       to: client.chain.consensusMainContract?.address as Address,
       data: transactionVariant.encodedData,
       value: `0x${transactionVariant.value.toString(16)}`,
-      gas: `0x${estimatedGas.toString(16)}`,
+      gas: `0x${transactionGas.toString(16)}`,
       nonce: `0x${nonceBigInt.toString(16)}`,
       type: "0x0", // legacy tx
       chainId: `0x${client.chain.id.toString(16)}`,
@@ -2438,9 +2454,7 @@ const _sendTransaction = async ({
 
     if (externalReceipt.status === "reverted") {
       throw new Error(
-        `Transaction reverted: EVM tx ${evmTxHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.${
-          gasEstimationError ? ` Gas estimation error: ${gasEstimationError}` : ""
-        }`,
+        `Transaction reverted: EVM tx ${evmTxHash} to consensus contract ${client.chain.consensusMainContract?.address} was reverted.`,
       );
     }
 

--- a/src/types/clients.ts
+++ b/src/types/clients.ts
@@ -83,6 +83,12 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      /**
+       * Explicit gas limit for the outer EVM `addTransaction` call.
+       * This is the same transaction-level `gas` override exposed by viem's
+       * `sendTransaction`; it does not change GenLayer protocol fee budgets.
+       */
+      gas?: bigint;
     }) => Promise<any>;
     simulateWriteContract: <
       RawReturn extends boolean | undefined = undefined,
@@ -111,6 +117,8 @@ export type GenLayerClient<TGenLayerChain extends GenLayerChain> = Omit<
       consensusMaxRotations?: number;
       validUntil?: BigNumberish;
       fees?: TransactionFeeOptions;
+      /** Explicit gas limit for the outer EVM `addTransaction` call. */
+      gas?: bigint;
     }) => Promise<`0x${string}`>;
     getTransaction: (args: {hash: TransactionHash}) => Promise<GenLayerTransaction>;
     getCurrentNonce: (args: {address: Address}) => Promise<number>;

--- a/tests/contracts-actions.test.ts
+++ b/tests/contracts-actions.test.ts
@@ -663,6 +663,63 @@ describe("contractActions addTransaction ABI compatibility", () => {
     expect(encodedData.slice(0, 10)).toBe(selectorForV5);
   });
 
+  it("uses an explicit writeContract gas limit without estimating", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        value: 0n,
+        gas: 32_000_000n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    expect(signTransaction).toHaveBeenCalledWith(expect.objectContaining({gas: 32_000_000n}));
+  });
+
+  it("uses an explicit deployContract gas limit without estimating", async () => {
+    const signTransaction = vi.fn().mockRejectedValue(new Error("stop_after_encoding"));
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.deployContract({
+        code: "print('hello')",
+        gas: 31_000_000n,
+      }),
+    ).rejects.toThrow("stop_after_encoding");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    expect(signTransaction).toHaveBeenCalledWith(expect.objectContaining({gas: 31_000_000n}));
+  });
+
+  it.each([0n, -1n])("rejects a non-positive gas limit (%s)", async (gas) => {
+    const signTransaction = vi.fn();
+    const {actions, estimateTransactionGas} = setupWriteContractHarness({
+      initialAbi: ADD_TRANSACTION_ABI_V5,
+      signTransactionMock: signTransaction,
+    });
+
+    await expect(
+      actions.writeContract({
+        address: RECIPIENT_ADDRESS,
+        functionName: "ping",
+        gas,
+      }),
+    ).rejects.toThrow("gas must be a positive bigint");
+
+    expect(estimateTransactionGas).not.toHaveBeenCalled();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
   it("encodes addTransaction with 6 args when ABI has 6 inputs", async () => {
     const {actions, estimateTransactionGas} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_V6,
@@ -1737,8 +1794,7 @@ describe("contractActions addTransaction ABI compatibility", () => {
     ).rejects.toThrow("Transaction reverted");
   });
 
-  it("decodes BudgetTooLow selector from gas estimation failures", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  it("decodes estimation failures and stops before broadcast", async () => {
     const signTransaction = vi.fn().mockResolvedValue("0xsigned");
     const {actions, estimateTransactionGas, client} = setupWriteContractHarness({
       initialAbi: ADD_TRANSACTION_ABI_WITH_FEES,
@@ -1750,9 +1806,10 @@ describe("contractActions addTransaction ABI compatibility", () => {
 
     await expect(
       actions.writeContract({address: RECIPIENT_ADDRESS, functionName: "ping", value: 0n}),
-    ).rejects.toThrow(/BudgetTooLow/);
+    ).rejects.toThrow(/no transaction was sent[\s\S]*BudgetTooLow/);
 
-    consoleError.mockRestore();
+    expect(signTransaction).not.toHaveBeenCalled();
+    expect((client as any).sendRawTransaction).not.toHaveBeenCalled();
   });
 
   it("throws when external wallet receipt has no NewTransaction event", async () => {


### PR DESCRIPTION
# What

- Add top-level `gas?: bigint` to `writeContract` and `deployContract`.
- Use an explicit limit unchanged for both local-key and injected-wallet transactions.
- Keep the existing 2× estimation headroom when `gas` is omitted.
- Stop before signing or broadcast when estimation fails instead of silently falling back to 200,000.
- Document that this controls the outer EVM `ConsensusMain.addTransaction` call and is separate from GenLayer `fees`.

# Why

Large intelligent-contract deployment calldata can require more intrinsic EVM gas than the old 200,000 fallback. When estimation reverts, callers currently cannot supply the correct outer transaction limit, so the fallback can be rejected with `intrinsic gas too low` before GenLayer receives a deployment.

This unifies the intelligent-contract actions with viem's existing top-level `sendTransaction({ gas })` convention. It does not change GenLayer consensus/execution budgets or protocol fee accounting.

This is an organization-owned replacement for #205 and credits @ygd58 for the original gas-override proposal and test approach.

# Testing done

- `npm test -- --run` — 130 tests passed; no type errors.
- `npm run build` — ESM, CJS, and declaration builds passed.
- `npx eslint . --ext .ts` — passed.
- Added coverage for write/deploy overrides, invalid limits, estimation bypass, and no-broadcast estimation failures.

# Decisions made

- Reuse the public name `gas` rather than introducing a GenLayer-specific name.
- Keep the current 2× estimated-gas safety margin for callers that omit the override.
- Treat estimation failure as actionable and non-broadcasting; callers may inspect the revert or retry with an explicit limit.
- No protocol, consensus, or fee-budget behavior changes.

# Risk and rollback

The behavioral change is limited to intelligent-contract writes/deployments whose gas estimation fails: they now fail early instead of broadcasting with 200,000. Reverting this commit restores the previous fallback.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

Start with `_sendTransaction` in `src/contracts/actions.ts`, then review the public types and the focused tests.

# User facing release notes

`writeContract` and `deployContract` now accept an optional top-level `gas` limit for the outer EVM transaction. This is separate from GenLayer `fees`. If estimation fails and no limit is supplied, the SDK stops before broadcast with a clear error.