### PR TITLE
Fix calldata toString to match the reference to_str format

### DIFF
--- a/src/abi/calldata/string.ts
+++ b/src/abi/calldata/string.ts
@@ -7,7 +7,12 @@ function reportError(msg: string, data: CalldataEncodable): never {
 
 function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string[]) {
     to.push("{");
+    let first = true;
     for (const [k, v] of data) {
+      if (!first) {
+        to.push(",");
+      }
+      first = false;
       to.push(JSON.stringify(k));
       to.push(":");
       toStringImpl(v, to);
@@ -48,13 +53,15 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         if (data instanceof Uint8Array) {
           to.push("b#");
           for (const b of data) {
-            to.push(b.toString(16));
+            to.push(b.toString(16).padStart(2, "0"));
           }
         } else if (data instanceof Array) {
           to.push("[");
-          for (const c of data) {
-            toStringImpl(c, to);
-            to.push(",");
+          for (let i = 0; i < data.length; i++) {
+            if (i > 0) {
+              to.push(",");
+            }
+            toStringImpl(data[i], to);
           }
           to.push("]");
         } else if (data instanceof Map) {
@@ -62,7 +69,7 @@ function toStringImplMap(data: Iterable<[string, CalldataEncodable]>, to: string
         } else if (data instanceof CalldataAddress) {
           to.push("addr#");
           for (const c of data.bytes) {
-            to.push(c.toString(16));
+            to.push(c.toString(16).padStart(2, "0"));
           }
         } else if (Object.getPrototypeOf(data) === Object.prototype) {
           toStringImplMap(Object.entries(data), to);

--- a/tests/calldata-string.test.ts
+++ b/tests/calldata-string.test.ts
@@ -1,0 +1,23 @@
+import {describe, it, expect} from "vitest";
+import {toString} from "../src/abi/calldata/string";
+import {CalldataAddress} from "../src/types/calldata";
+
+describe("calldata toString", () => {
+  it("zero-pads byte strings", () => {
+    expect(toString(new Uint8Array([0x01, 0x02]))).toBe("b#0102");
+    expect(toString(new Uint8Array([0x0a, 0x00, 0xff]))).toBe("b#0a00ff");
+  });
+
+  it("zero-pads addresses to 40 hex chars", () => {
+    const addr = new CalldataAddress(new Uint8Array(20).fill(0x01));
+    expect(toString(addr)).toBe("addr#" + "01".repeat(20));
+  });
+
+  it("separates object entries with commas", () => {
+    expect(toString({x: true, y: null})).toBe('{"x":true,"y":null}');
+  });
+
+  it("does not leave a trailing comma in arrays", () => {
+    expect(toString([1, 2, 3])).toBe("[1,2,3]");
+  });
+});

--- a/tests/calldata-string.test.ts
+++ b/tests/calldata-string.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from "vitest";
-import {toString} from "../src/abi/calldata/string";
-import {CalldataAddress} from "../src/types/calldata";
+import {toString} from "@/abi/calldata/string";
+import {CalldataAddress} from "@/types/calldata";
 
 describe("calldata toString", () => {
   it("zero-pads byte strings", () => {


### PR DESCRIPTION
`abi.calldata.toString()` diverged from the reference `to_str` (genlayer-py-std) in three ways, all in `src/abi/calldata/string.ts`. Since it feeds the `readable` field of `decodeTransaction` / `simplifyTransactionReceipt`, the malformed output reached end users.

| Input | before | after / reference |
|---|---|---|
| `Uint8Array([0x01,0x02])` | `b#12` | `b#0102` |
| 20-byte address of `0x01` | `addr#11111111111111111111` | `addr#0101…0101` (40 chars) |
| `{x:true, y:null}` | `{"x":true"y":null}` | `{"x":true,"y":null}` |
| `[1,2,3]` | `[1,2,3,]` | `[1,2,3]` |

- Pad each byte to two hex chars (`toString(16).padStart(2,"0")`).
- Emit a comma between object entries.
- Emit the array comma before each element except the first.

Added `tests/calldata-string.test.ts` covering all four cases against the reference values. `npm run lint` and `npm run build` pass.

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected calldata formatting for map and array values by placing separators between elements without trailing commas.
  - Ensured byte values are consistently formatted with two-character hexadecimal padding.
  - Ensured address values use consistent 40-character hexadecimal formatting.

- **Tests**
  - Added coverage for byte, address, object, and array serialization formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->